### PR TITLE
Add requesting job status and results from backend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Then run:
 ```
 
 
-To start the application, run:
+To start all required components, run:
 ```
-./scripts/run
+./scripts/run_test
 ```
 
-The website can be viewed at http://localhost:8080/ . You can stop the application with `Ctrl+C`.
+The website can be viewed at http://localhost:8080/ . You can stop the application with `./scripts/stop_test`.
 
 
 ## Testing

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -18,7 +18,6 @@
         "sass-loader": "^12.6.0",
         "ts-md5": "^1.2.11",
         "ts-node": "^10.7.0",
-        "vm": "^0.1.0",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue3-dropzone": "^0.0.7",
@@ -49,7 +48,8 @@
         "jest": "^27.0.5",
         "lint-staged": "^11.1.2",
         "ts-jest": "^27.0.4",
-        "typescript": "~4.5.5"
+        "typescript": "~4.5.5",
+        "vm": "^0.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5710,9 +5710,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001382",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz",
+      "integrity": "sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -18114,7 +18124,8 @@
     "node_modules/vm": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/vm/-/vm-0.1.0.tgz",
-      "integrity": "sha512-1aKVjgohVDnVhGrJLhl2k8zIrapH+7HsdnIjGvBp3XX2OCj6XGzsIbDp9rZ3r7t6qgDfXEE1EoEAEOLJm9LKnw=="
+      "integrity": "sha512-1aKVjgohVDnVhGrJLhl2k8zIrapH+7HsdnIjGvBp3XX2OCj6XGzsIbDp9rZ3r7t6qgDfXEE1EoEAEOLJm9LKnw==",
+      "dev": true
     },
     "node_modules/vue": {
       "version": "3.2.31",
@@ -23544,9 +23555,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001382",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz",
+      "integrity": "sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -33241,7 +33252,8 @@
     "vm": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/vm/-/vm-0.1.0.tgz",
-      "integrity": "sha512-1aKVjgohVDnVhGrJLhl2k8zIrapH+7HsdnIjGvBp3XX2OCj6XGzsIbDp9rZ3r7t6qgDfXEE1EoEAEOLJm9LKnw=="
+      "integrity": "sha512-1aKVjgohVDnVhGrJLhl2k8zIrapH+7HsdnIjGvBp3XX2OCj6XGzsIbDp9rZ3r7t6qgDfXEE1EoEAEOLJm9LKnw==",
+      "dev": true
     },
     "vue": {
       "version": "3.2.31",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -67,7 +67,9 @@
     },
     "rules": {
       "no-shadow": "off",
-      "@typescript-eslint/no-shadow": ["error"]
+      "@typescript-eslint/no-shadow": [
+        "error"
+      ]
     },
     "overrides": [
       {

--- a/app/client/playwright.config.ts
+++ b/app/client/playwright.config.ts
@@ -13,14 +13,14 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 20000
+    timeout: 30000
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/app/client/playwright.config.ts
+++ b/app/client/playwright.config.ts
@@ -7,13 +7,13 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './tests/e2e',
   /* Maximum time one test can run for. */
-  timeout: 100 * 1000,
+  timeout: 1000 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 30000
+    timeout: 300000
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,

--- a/app/client/src/components/DropZone.vue
+++ b/app/client/src/components/DropZone.vue
@@ -11,6 +11,7 @@
       {{file.filename}} {{file.hash}}
       {{file.amr ? file.amr.slice(2, 10): ""}}
       {{file.sketch ? file.sketch.slice(2, 4): ""}}
+      {{file.cluster ? file.cluster: ""}}
     </p></div>
     <p class="count">{{ Object.keys(results.perIsolate).length }}</p>
   </div>

--- a/app/client/src/components/LoginPrompt.vue
+++ b/app/client/src/components/LoginPrompt.vue
@@ -9,7 +9,7 @@
   </div>
 </template>
 
-<script>
+<script lang='ts'>
 import { defineComponent } from 'vue';
 import config from '@/resources/config.json';
 

--- a/app/client/src/components/StartButton.vue
+++ b/app/client/src/components/StartButton.vue
@@ -16,11 +16,19 @@ import { mapActions, mapMutations, mapState } from 'vuex';
 export default defineComponent({
   name: 'StartButton',
   methods: {
-    ...mapMutations(['setStatus']),
-    ...mapActions(['runPoppunk']),
+    updateStatus() {
+      const inter = setInterval(this.getStatus, 1000);
+      this.setStatusInterval(inter);
+    },
+    stopUpdateStatus() {
+      clearInterval(this.statusInterval);
+    },
+    ...mapMutations(['setStatus', 'setStatusInterval']),
+    ...mapActions(['runPoppunk', 'getStatus', 'getAssignResult']),
     onClick() {
       this.runPoppunk();
       this.setStatus({ task: 'submitted', data: 'submitted' });
+      this.updateStatus();
     },
   },
   computed: {
@@ -33,7 +41,20 @@ export default defineComponent({
       });
       return all;
     },
-    ...mapState(['analysisStatus', 'results']),
+    ...mapState(['analysisStatus', 'results', 'statusInterval']),
+  },
+  watch: {
+    analysisStatus: {
+      handler(newVal) {
+        if (newVal.assign === 'finished') {
+          this.getAssignResult();
+        }
+        if ((newVal.network === 'finished' || newVal.network === 'failed') && (newVal.microreact === 'finished' || newVal.microreact === 'failed')) {
+          this.stopUpdateStatus();
+        }
+      },
+      deep: true,
+    },
   },
 });
 </script>

--- a/app/client/src/components/StartButton.vue
+++ b/app/client/src/components/StartButton.vue
@@ -11,13 +11,12 @@
 
 <script lang='ts'>
 import { defineComponent } from 'vue';
-import { mapActions, mapMutations, mapState } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 
 export default defineComponent({
   name: 'StartButton',
   methods: {
-    ...mapMutations(['setSubmitStatus']),
-    ...mapActions(['runPoppunk', 'startStatusPolling', 'submitData']),
+    ...mapActions(['submitData']),
     onClick() {
       this.submitData();
     },
@@ -32,7 +31,7 @@ export default defineComponent({
       });
       return all;
     },
-    ...mapState(['submitStatus', 'analysisStatus', 'results', 'statusInterval']),
+    ...mapState(['submitStatus', 'analysisStatus', 'results']),
   },
 });
 </script>

--- a/app/client/src/components/StartButton.vue
+++ b/app/client/src/components/StartButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="start-analysis">
-    <button :class="(!analysisStatus.submitted && allSketched) ? '' : 'disabled'"
+    <button :class="(!submitStatus && allSketched) ? '' : 'disabled'"
     class="btn btn-block btn-standard"
     @click='onClick'>
       Start Analysis</button>
@@ -17,11 +17,9 @@ export default defineComponent({
   name: 'StartButton',
   methods: {
     ...mapMutations(['setSubmitStatus']),
-    ...mapActions(['runPoppunk', 'getStatus', 'startStatusPolling']),
+    ...mapActions(['runPoppunk', 'startStatusPolling', 'submitData']),
     onClick() {
-      this.runPoppunk();
-      this.setSubmitStatus('submitted');
-      this.startStatusPolling();
+      this.submitData();
     },
   },
   computed: {

--- a/app/client/src/components/StartButton.vue
+++ b/app/client/src/components/StartButton.vue
@@ -5,7 +5,7 @@
     @click='onClick'>
       Start Analysis</button>
     <!--only adding this temporarily to have something testable for e2e tests-->
-    <p class="status" v-if='analysisStatus.submitted'>{{analysisStatus}}</p>
+    <p class="status" v-if='submitStatus'>{{analysisStatus}}</p>
   </div>
 </template>
 
@@ -16,19 +16,12 @@ import { mapActions, mapMutations, mapState } from 'vuex';
 export default defineComponent({
   name: 'StartButton',
   methods: {
-    updateStatus() {
-      const inter = setInterval(this.getStatus, 1000);
-      this.setStatusInterval(inter);
-    },
-    stopUpdateStatus() {
-      clearInterval(this.statusInterval);
-    },
-    ...mapMutations(['setStatus', 'setStatusInterval']),
-    ...mapActions(['runPoppunk', 'getStatus', 'getAssignResult']),
+    ...mapMutations(['setSubmitStatus']),
+    ...mapActions(['runPoppunk', 'getStatus', 'startStatusPolling']),
     onClick() {
       this.runPoppunk();
-      this.setStatus({ task: 'submitted', data: 'submitted' });
-      this.updateStatus();
+      this.setSubmitStatus('submitted');
+      this.startStatusPolling();
     },
   },
   computed: {
@@ -41,20 +34,7 @@ export default defineComponent({
       });
       return all;
     },
-    ...mapState(['analysisStatus', 'results', 'statusInterval']),
-  },
-  watch: {
-    analysisStatus: {
-      handler(newVal) {
-        if (newVal.assign === 'finished') {
-          this.getAssignResult();
-        }
-        if ((newVal.network === 'finished' || newVal.network === 'failed') && (newVal.microreact === 'finished' || newVal.microreact === 'failed')) {
-          this.stopUpdateStatus();
-        }
-      },
-      deep: true,
-    },
+    ...mapState(['submitStatus', 'analysisStatus', 'results', 'statusInterval']),
   },
 });
 </script>

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -89,4 +89,10 @@ export default {
     const inter = setInterval(() => { dispatch('getStatus'); }, 1000);
     commit('setStatusInterval', inter);
   },
+  async submitData(context: ActionContext<RootState, RootState>) {
+    const { dispatch, commit } = context;
+    dispatch('runPoppunk');
+    commit('setSubmitStatus', 'submitted');
+    dispatch('startStatusPolling');
+  },
 };

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -61,4 +61,40 @@ export default {
       commit('setStatus', { task: 'network', data: 'submitted' });
     });
   },
+  async getStatus({ commit, state }: { commit: Commit, state: RootState }) {
+    await axios.post(
+      `${config.server_url}/status`,
+      { hash: state.projectHash },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    ).then((response) => {
+      const prev = { ...state.analysisStatus };
+      if (response.data.data.microreact !== prev.microreact) {
+        commit('setStatus', { task: 'microreact', data: response.data.data.microreact });
+      }
+      if (response.data.data.network !== prev.network) {
+        commit('setStatus', { task: 'network', data: response.data.data.network });
+      }
+      if (response.data.data.assign !== prev.assign) {
+        commit('setStatus', { task: 'assign', data: response.data.data.assign });
+      }
+    });
+  },
+  async getAssignResult({ commit, state }: { commit: Commit, state: RootState }) {
+    await axios.post(
+      `${config.server_url}/assignResult`,
+      { projectHash: state.projectHash },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+      .then((response) => {
+        commit('setClusters', response.data);
+      });
+  },
 };

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -17,6 +17,7 @@ export default new Vuex.Store<RootState>({
       microreact: null,
       network: null,
     },
+    statusInterval: null,
   },
   getters: {
   },

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -11,13 +11,13 @@ export default new Vuex.Store<RootState>({
       perIsolate: {},
     },
     projectHash: null,
+    submitStatus: null,
     analysisStatus: {
-      submitted: null,
       assign: null,
       microreact: null,
       network: null,
     },
-    statusInterval: null,
+    statusInterval: undefined,
   },
   getters: {
   },

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -1,6 +1,6 @@
 import { RootState } from '@/store/state';
 import {
-  Versions, User, IsolateValue, Status, ClusterInfo,
+  Versions, User, IsolateValue, AnalysisStatus, ClusterInfo,
 } from '@/types';
 
 export default {
@@ -24,8 +24,11 @@ export default {
   setProjectHash(state: RootState, phash: string) {
     state.projectHash = phash;
   },
-  setStatus(state: RootState, status: Status) {
-    state.analysisStatus[status.task] = status.data;
+  setSubmitStatus(state: RootState, data: string) {
+    state.submitStatus = data;
+  },
+  setAnalysisStatus(state: RootState, data: AnalysisStatus) {
+    state.analysisStatus = data;
   },
   setStatusInterval(state: RootState, interval: number) {
     state.statusInterval = interval;

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -1,6 +1,6 @@
 import { RootState } from '@/store/state';
 import {
-  Versions, User, IsolateValue, Status,
+  Versions, User, IsolateValue, Status, ClusterInfo,
 } from '@/types';
 
 export default {
@@ -21,10 +21,19 @@ export default {
   setIsolateValue(state: RootState, input: IsolateValue) {
     state.results.perIsolate[input.hash][input.type] = input.result;
   },
+  setProjectHash(state: RootState, phash: string) {
+    state.projectHash = phash;
+  },
   setStatus(state: RootState, status: Status) {
     state.analysisStatus[status.task] = status.data;
   },
-  setProjectHash(state: RootState, phash: string) {
-    state.projectHash = phash;
+  setStatusInterval(state: RootState, interval: number) {
+    state.statusInterval = interval;
+  },
+  setClusters(state: RootState, clusterInfo: ClusterInfo) {
+    Object.keys(clusterInfo.data).forEach((element) => {
+      state.results.perIsolate[clusterInfo.data[element].hash]
+        .cluster = clusterInfo.data[element].cluster;
+    });
   },
 };

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -11,4 +11,5 @@ export interface RootState {
   results: Results
   analysisStatus: AnalysisStatus
   projectHash: string | null
+  statusInterval: number | null
 }

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -9,7 +9,8 @@ export interface RootState {
   versions: Versions | []
   user: User | null
   results: Results
+  submitStatus: string | null
   analysisStatus: AnalysisStatus
   projectHash: string | null
-  statusInterval: number | null
+  statusInterval: number | undefined
 }

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -36,7 +36,6 @@ export interface IsolateValue {
 }
 
 export enum AnalysisType {
-    SUBMITTED = 'submitted',
     ASSIGN = 'assign',
     MICROREACT = 'microreact',
     NETWORK = 'network'
@@ -44,11 +43,6 @@ export enum AnalysisType {
 
 export type AnalysisStatus = {
     [key in AnalysisType]: string | null
-}
-
-export type Status = {
-    task: AnalysisType
-    data: string
 }
 
 export interface ClusterInfo {

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -5,6 +5,7 @@ export interface Isolate {
     filename?: string
     amr?: string
     sketch?: string
+    cluster?: string
 }
 
 export interface Versions {
@@ -48,4 +49,8 @@ export type AnalysisStatus = {
 export type Status = {
     task: AnalysisType
     data: string
+}
+
+export interface ClusterInfo {
+    data: Dict<Dict<string>>
 }

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -54,8 +54,16 @@ test.describe('Logged in Tests', () => {
     // Expect to see 'submitted' status once button was pressed
     await page.click('text=Start Analysis');
     await expect(page.locator('.status')).toContainText('"submitted": "submitted"');
-    await expect(page.locator('.status')).toContainText('"assign": "submitted"');
-    await expect(page.locator('.status')).toContainText('"microreact": "submitted"');
-    await expect(page.locator('.status')).toContainText('"network": "submitted"');
+    await expect(page.locator('.status')).toContainText('"assign"');
+    await expect(page.locator('.status')).toContainText('"microreact"');
+    await expect(page.locator('.status')).toContainText('"network"');
+    // Expect clusters appearing in file list
+    await expect(page.locator('.uploaded-info')).toContainText('6930_8_13.fa e868c76fec83ee1f69a95bd27b8d5e76 filename 14 7');
+    await expect(page.locator('.uploaded-info')).toContainText('6930_8_11.fa f3d9b387e311d5ab59a8c08eb3545dbb filename 14 24');
+    // Expect all statuses to be updated to finished
+    await page.waitForTimeout(20000);
+    await expect(page.locator('.status')).toContainText('"assign": "finished"');
+    await expect(page.locator('.status')).toContainText('"microreact": "finished"');
+    await expect(page.locator('.status')).toContainText('"network": "finished"');
   });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -53,7 +53,6 @@ test.describe('Logged in Tests', () => {
     await expect(page.locator('.start-analysis')).toContainText('Start Analysis');
     // Expect to see 'submitted' status once button was pressed
     await page.click('text=Start Analysis');
-    await expect(page.locator('.status')).toContainText('"submitted": "submitted"');
     await expect(page.locator('.status')).toContainText('"assign"');
     await expect(page.locator('.status')).toContainText('"microreact"');
     await expect(page.locator('.status')).toContainText('"network"');

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -9,10 +9,11 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
     versions: [],
     user: null,
     results: { perIsolate: {} },
+    submitStatus: null,
     analysisStatus: {
-      submitted: null, assign: null, microreact: null, network: null,
+      assign: null, microreact: null, network: null,
     },
-    statusInterval: null,
+    statusInterval: undefined,
     projectHash: null,
     ...state,
   };

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -12,6 +12,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
     analysisStatus: {
       submitted: null, assign: null, microreact: null, network: null,
     },
+    statusInterval: null,
     projectHash: null,
     ...state,
   };

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -64,12 +64,6 @@ describe('StartButton', () => {
 });
 
 describe('StartButton disabled', () => {
-  const runPoppunk = jest.fn();
-  const getStatus = jest.fn();
-  const getAssignResult = jest.fn();
-  const setStatus = jest.fn();
-  const setStatusInterval = jest.fn();
-
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
       user: {
@@ -95,15 +89,47 @@ describe('StartButton disabled', () => {
         },
       },
     }),
-    actions: {
-      runPoppunk,
-      getStatus,
-      getAssignResult,
+  });
+  const wrapper = mount(StartButton, {
+    global: {
+      plugins: [store],
     },
-    mutations: {
-      setStatus,
-      setStatusInterval,
-    },
+  });
+  
+  it('disables Button when not all sketches are ready', () => {
+    expect(wrapper.find('button').attributes('class')).toContain('disabled');
+  });
+});
+
+describe('StartButton disabled after submit', () => {
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      submitStatus: 'submitted',
+      user: {
+        status: 'success',
+        errors: [],
+        data: {
+          name: 'Jane',
+          id: '543653d45',
+          provider: 'google',
+        },
+      },
+      results: {
+        perIsolate: {
+          someHash: {
+            hash: 'someHash',
+            filename: 'example.fa',
+            sketch: 'sketch',
+          },
+          someHash2: {
+            hash: 'someHash2',
+            filename: 'example2.fa',
+            sketch: 'sketch',
+          },
+        },
+      },
+    }),
   });
   const wrapper = mount(StartButton, {
     global: {

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -1,0 +1,144 @@
+import StartButton from '@/components/StartButton.vue';
+import { mount } from '@vue/test-utils';
+import { RootState } from '@/store/state';
+import Vuex from 'vuex';
+import { mockRootState } from '../../mocks';
+
+describe('StartButton', () => {
+  const runPoppunk = jest.fn();
+  const getStatus = jest.fn();
+  const getAssignResult = jest.fn();
+  const setStatus = jest.fn();
+  const setStatusInterval = jest.fn();
+  const stopUpdateStatus = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      user: {
+        status: 'success',
+        errors: [],
+        data: {
+          name: 'Jane',
+          id: '543653d45',
+          provider: 'google',
+        },
+      },
+      results: {
+        perIsolate: {
+          someHash: {
+            hash: 'someHash',
+            filename: 'example.fa',
+            sketch: 'sketch',
+          },
+        },
+      },
+    }),
+    actions: {
+      runPoppunk,
+      getStatus,
+      getAssignResult,
+    },
+    mutations: {
+      setStatus,
+      setStatusInterval,
+    },
+  });
+  const wrapper = mount(StartButton, {
+    global: {
+      plugins: [store],
+    },
+
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('onClick triggers actions', () => {
+    wrapper.vm.onClick();
+    expect(runPoppunk).toHaveBeenCalledTimes(1);
+    expect(setStatus.mock.calls[0][1]).toStrictEqual({ task: 'submitted', data: 'submitted' });
+    expect(setStatusInterval).toHaveBeenCalledTimes(1);
+    expect(setStatusInterval).toHaveBeenCalledWith(store.state, expect.any(Number));
+  });
+
+  it('watcher requests results when assign results are finished', () => {
+    const updatedAnalysisStatus = {
+      submitted: 'submitted',
+      assign: 'finished',
+      microreact: 'started',
+      network: 'queued',
+    };
+      // wrapper.vm.$options.watch?.analysisStatus.handler.call(wrapper.vm, updatedAnalysisStatus);
+      // expect(getAssignResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('watcher stops updating status when all results are finished', () => {
+    expect(getAssignResult).toHaveBeenCalledTimes(1);
+    const finishedAnalysisStatus = {
+      submitted: 'submitted',
+      assign: 'finished',
+      microreact: 'finished',
+      network: 'finished',
+    };
+      // wrapper.vm.$options.watch?.analysisStatus.handler.call(wrapper.vm, finishedAnalysisStatus);
+      // expect(stopUpdateStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Dropzone', () => {
+  const runPoppunk = jest.fn();
+  const getStatus = jest.fn();
+  const getAssignResult = jest.fn();
+  const setStatus = jest.fn();
+  const setStatusInterval = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      user: {
+        status: 'success',
+        errors: [],
+        data: {
+          name: 'Jane',
+          id: '543653d45',
+          provider: 'google',
+        },
+      },
+      results: {
+        perIsolate: {
+          someHash: {
+            hash: 'someHash',
+            filename: 'example.fa',
+            sketch: 'sketch',
+          },
+          someHash2: {
+            hash: 'someHash2',
+            filename: 'example2.fa',
+          },
+        },
+      },
+    }),
+    actions: {
+      runPoppunk,
+      getStatus,
+      getAssignResult,
+    },
+    mutations: {
+      setStatus,
+      setStatusInterval,
+    },
+  });
+  const wrapper = mount(StartButton, {
+    global: {
+      plugins: [store],
+    },
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('disables Button when not all sketches are ready', () => {
+    expect(wrapper.find('button').attributes('class')).toContain('disabled');
+  });
+});

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -11,6 +11,7 @@ describe('StartButton', () => {
   const setSubmitStatus = jest.fn();
   const setStatusInterval = jest.fn();
   const startStatusPolling = jest.fn();
+  const submitData = jest.fn();
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
@@ -38,6 +39,7 @@ describe('StartButton', () => {
       getStatus,
       getAssignResult,
       startStatusPolling,
+      submitData,
     },
     mutations: {
       setSubmitStatus,
@@ -57,9 +59,7 @@ describe('StartButton', () => {
 
   it('onClick triggers actions', () => {
     wrapper.vm.onClick();
-    expect(runPoppunk).toHaveBeenCalledTimes(1);
-    expect(setSubmitStatus.mock.calls[0][1]).toStrictEqual('submitted');
-    expect(startStatusPolling).toHaveBeenCalledTimes(1);
+    expect(submitData).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -74,7 +74,6 @@ describe('StartButton', () => {
   });
 
   it('watcher stops updating status when all results are finished', () => {
-    expect(getAssignResult).toHaveBeenCalledTimes(1);
     const finishedAnalysisStatus = {
       submitted: 'submitted',
       assign: 'finished',

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -8,9 +8,9 @@ describe('StartButton', () => {
   const runPoppunk = jest.fn();
   const getStatus = jest.fn();
   const getAssignResult = jest.fn();
-  const setStatus = jest.fn();
+  const setSubmitStatus = jest.fn();
   const setStatusInterval = jest.fn();
-  const stopUpdateStatus = jest.fn();
+  const startStatusPolling = jest.fn();
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
@@ -37,9 +37,10 @@ describe('StartButton', () => {
       runPoppunk,
       getStatus,
       getAssignResult,
+      startStatusPolling,
     },
     mutations: {
-      setStatus,
+      setSubmitStatus,
       setStatusInterval,
     },
   });
@@ -57,35 +58,12 @@ describe('StartButton', () => {
   it('onClick triggers actions', () => {
     wrapper.vm.onClick();
     expect(runPoppunk).toHaveBeenCalledTimes(1);
-    expect(setStatus.mock.calls[0][1]).toStrictEqual({ task: 'submitted', data: 'submitted' });
-    expect(setStatusInterval).toHaveBeenCalledTimes(1);
-    expect(setStatusInterval).toHaveBeenCalledWith(store.state, expect.any(Number));
-  });
-
-  it('watcher requests results when assign results are finished', () => {
-    const updatedAnalysisStatus = {
-      submitted: 'submitted',
-      assign: 'finished',
-      microreact: 'started',
-      network: 'queued',
-    };
-      // wrapper.vm.$options.watch?.analysisStatus.handler.call(wrapper.vm, updatedAnalysisStatus);
-      // expect(getAssignResult).toHaveBeenCalledTimes(1);
-  });
-
-  it('watcher stops updating status when all results are finished', () => {
-    const finishedAnalysisStatus = {
-      submitted: 'submitted',
-      assign: 'finished',
-      microreact: 'finished',
-      network: 'finished',
-    };
-      // wrapper.vm.$options.watch?.analysisStatus.handler.call(wrapper.vm, finishedAnalysisStatus);
-      // expect(stopUpdateStatus).toHaveBeenCalledTimes(1);
+    expect(setSubmitStatus.mock.calls[0][1]).toStrictEqual('submitted');
+    expect(startStatusPolling).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('Dropzone', () => {
+describe('StartButton disabled', () => {
   const runPoppunk = jest.fn();
   const getStatus = jest.fn();
   const getAssignResult = jest.fn();

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -220,4 +220,14 @@ describe('Actions', () => {
       expResponse,
     ]);
   });
+
+  it('submitData triggers runPoppunk, startStatusPolling and sets submitStatus', async () => {
+    const commit = jest.fn();
+    const dispatch = jest.fn();
+    await actions.submitData({ commit, dispatch } as any);
+    expect(commit.mock.calls[0][0]).toEqual('setSubmitStatus');
+    expect(commit.mock.calls[0][1]).toEqual('submitted');
+    expect(dispatch.mock.calls[0][0]).toEqual('runPoppunk');
+    expect(dispatch.mock.calls[1][0]).toEqual('startStatusPolling');
+  });
 });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -9,7 +9,7 @@ function responseSuccess(data : any) {
   return {
     status: 'success',
     errors: [],
-    data: { data },
+    data,
   };
 }
 
@@ -102,5 +102,62 @@ describe('Actions', () => {
     expect(commit.mock.calls[1]).toEqual([
       'setStatus',
       { task: 'assign', data: 'submitted' }]);
+  });
+
+  it('getStatus makes axios call and updates analysisStatus', async () => {
+    const commit = jest.fn();
+    const state = mockRootState({
+      projectHash: 'randomHash',
+      analysisStatus: {
+        submitted: 'submitted',
+        assign: 'started',
+        microreact: 'waiting',
+        network: 'waiting',
+      },
+    });
+    mockAxios.onPost(`${config.server_url}/status`).reply(200, responseSuccess({
+      submitted: 'submitted', assign: 'finished', microreact: 'started', network: 'queued',
+    }));
+    await actions.getStatus({ commit, state });
+    expect(mockAxios.history.post[0].url).toEqual(`${config.server_url}/status`);
+    expect(commit.mock.calls[0]).toEqual([
+      'setStatus',
+      {
+        task: 'microreact',
+        data: 'started',
+      },
+    ]);
+    expect(commit.mock.calls[1]).toEqual([
+      'setStatus',
+      {
+        task: 'network',
+        data: 'queued',
+      },
+    ]);
+  });
+
+  it('getAssignResult makes axios call and updates clusters', async () => {
+    const commit = jest.fn();
+    const state = mockRootState({
+      projectHash: 'randomHash',
+      results: {
+        perIsolate: {
+          someFileHash: {
+            hash: 'someFileHash',
+          },
+          someFileHash2: {
+            hash: 'someFileHash2',
+          },
+        },
+      },
+    });
+    const expResponse = responseSuccess({ 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } });
+    mockAxios.onPost(`${config.server_url}/assignResult`).reply(200, expResponse);
+    await actions.getAssignResult({ commit, state });
+    expect(mockAxios.history.post[0].url).toEqual(`${config.server_url}/assignResult`);
+    expect(commit.mock.calls[0]).toEqual([
+      'setClusters',
+      expResponse,
+    ]);
   });
 });

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -68,4 +68,26 @@ describe('mutations', () => {
     mutations.setProjectHash(state, phash);
     expect(state.projectHash).toBe(phash);
   });
+  it('sets statusInterval', () => {
+    const state = mockRootState();
+    const interval = 122;
+    mutations.setStatusInterval(state, interval);
+    expect(state.statusInterval).toBe(interval);
+  });
+  it('sets cluster', () => {
+    const state = mockRootState({
+      results: {
+        perIsolate: {
+          someFileHash: {
+            hash: 'someFileHash',
+          },
+          someFileHash2: {
+            hash: 'someFileHash2',
+          },
+        },
+      },
+    });
+    mutations.setClusters(state, { data: { 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } } });
+    expect(state.results.perIsolate.someFileHash.cluster).toBe('12');
+  });
 });

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -1,5 +1,5 @@
 import mutations from '@/store/mutations';
-import { ValueTypes, Status, AnalysisType } from '@/types';
+import { ValueTypes } from '@/types';
 import { mockRootState } from '../../mocks';
 
 describe('mutations', () => {
@@ -53,14 +53,20 @@ describe('mutations', () => {
       amr: 'amr_result',
     });
   });
-  it('sets status', () => {
+  it('sets submitStatus', () => {
     const state = mockRootState();
-    const statusUpdate: Status = {
-      task: AnalysisType.MICROREACT,
-      data: 'submitted',
+    mutations.setSubmitStatus(state, 'submitted');
+    expect(state.submitStatus).toBe('submitted');
+  });
+  it('sets analysisStatus', () => {
+    const state = mockRootState();
+    const statusUpdate = {
+      assign: 'finished',
+      microreact: 'started',
+      network: 'queued',
     };
-    mutations.setStatus(state, statusUpdate);
-    expect(state.analysisStatus[statusUpdate.task]).toBe(statusUpdate.data);
+    mutations.setAnalysisStatus(state, statusUpdate);
+    expect(state.analysisStatus).toBe(statusUpdate);
   });
   it('sets projectHash', () => {
     const state = mockRootState();

--- a/app/client/tests/unit/views/HomeView.spec.ts
+++ b/app/client/tests/unit/views/HomeView.spec.ts
@@ -108,8 +108,9 @@ describe('Home', () => {
             someFileHash2: {},
           },
         },
+        submitStatus: null,
         analysisStatus: {
-          submitted: null, assign: null, microreact: null, network: null,
+          assign: null, microreact: null, network: null,
         },
       }),
       actions: {

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -18,6 +18,14 @@ export const router = (app => {
         authCheck,
         runPoppunk);
 
+    app.post('/status',
+        authCheck,
+        getStatus);
+
+    app.post('/assignResult',
+        authCheck,
+        getAssignResult);
+
     app.get('/login/google',
         passport.authenticate('google', { scope: ['profile'] }));
 
@@ -88,6 +96,28 @@ export async function runPoppunk(request, response) {
             }
         },
     )
+        .then(res => response.send(res.data))
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
+export async function getStatus(request, response) {
+    await axios.get(`${config.api_url}/status/${request.body.hash}`)
+        .then(res => response.send(res.data))
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
+export async function getAssignResult(request, response) {
+    await axios.post(`${config.api_url}/results/assign`,
+    request.body,
+    {
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
         .then(res => response.send(res.data))
         .catch(function (error) {
             console.log(error);

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,11 +4,12 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
+API_BRANCH=bacpop-39
 NAME_WORKER=beebop-py-worker
 PORT=5000
 
 docker volume create $VOLUME
-docker run --rm -v $VOLUME:/beebop/storage mrcide/beebop-py \
+docker run --rm -v $VOLUME:/beebop/storage mrcide/beebop-py:$API_BRANCH \
        ./scripts/download_db --small storage
 docker network create $NETWORK > /dev/null || /bin/true
 
@@ -16,14 +17,14 @@ docker run -d --rm --name $NAME_REDIS --network=$NETWORK redis:5.0
 docker run -d --rm --name $NAME_WORKER --network=$NETWORK \
        --env=REDIS_HOST="$NAME_REDIS" \
        -v $VOLUME:/beebop/storage \
-       mrcide/beebop-py rqworker
+       mrcide/beebop-py:$API_BRANCH rqworker
 docker run -d --rm --name $NAME_API --network=$NETWORK \
        --env=REDIS_HOST="$NAME_REDIS" \
        --env=STORAGE_LOCATION="./storage" \
        --env=DB_LOCATION="./storage/GPS_v4_references" \
        -v $VOLUME:/beebop/storage \
        -p $PORT:5000 \
-       mrcide/beebop-py
+       mrcide/beebop-py:$API_BRANCH
 
 npm --prefix app/server install
 npm --prefix app/client install


### PR DESCRIPTION
Once StartButton is clicked and sketches are submitted to backend, the frontend periodically requests job statuses until all jobs finished.

When assign results are ready, they are requested and added to state.

Unfortunatley not alle tests are working yet:
- Unit tests: StartButton.spec.ts:
    - [This line ]( https://github.com/bacpop/beebop/blob/98e5a669980f1b49c1c470dae47d57581b17937d/app/client/tests/unit/components/StartButton.spec.ts#L72 )gives a ts error
```Property 'handler' does not exist on type 'string'```
however when running the test, this line is processed correctly and the test passes
    - [This test ](https://github.com/bacpop/beebop/blob/98e5a669980f1b49c1c470dae47d57581b17937d/app/client/tests/unit/components/StartButton.spec.ts#L84) is not working ( also previous line same ts error as above), even though I do not understand why it should not, since it is so similar to the previous one. Any ideas?

- End-2-end tests: Playwright tests are taking super long. For now I have to increase the timeout by 10times, will reduce later to a more sensible value once I had time to see how long they actually take.