### PR TITLE
Add results table

### DIFF
--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -35,8 +35,8 @@ jobs:
       run: |
         npx playwright install
         npx playwright install-deps
-#    - name: tmate session
-#      uses: mxschmitt/action-tmate@v3
+    - name: tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Run e2e tests
       working-directory: ./app/client
       run: npx playwright test

--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -35,8 +35,8 @@ jobs:
       run: |
         npx playwright install
         npx playwright install-deps
-    - name: tmate session
-      uses: mxschmitt/action-tmate@v3
+#    - name: tmate session
+#      uses: mxschmitt/action-tmate@v3
     - name: Run e2e tests
       working-directory: ./app/client
       run: npx playwright test

--- a/app/client/src/components/DropZone.vue
+++ b/app/client/src/components/DropZone.vue
@@ -5,15 +5,7 @@
       <p v-if='isDragActive'>Drop the files here ...</p>
       <p v-else>Drag and drop your fasta files here, or click to select files</p>
     </div>
-    <p> Uploaded files:</p>
-    <!--only adding this temporarily to have something testable for e2e tests-->
-    <div class="uploaded-info"><p v-for="file in results.perIsolate" :key="file.hash">
-      {{file.filename}} {{file.hash}}
-      {{file.amr ? file.amr.slice(2, 10): ""}}
-      {{file.sketch ? file.sketch.slice(2, 4): ""}}
-      {{file.cluster ? file.cluster: ""}}
-    </p></div>
-    <p class="count">{{ Object.keys(results.perIsolate).length }}</p>
+    <p class="count"> Uploaded files: {{ Object.keys(results.perIsolate).length }}</p>
   </div>
 </template>
 

--- a/app/client/src/components/ResultsTable.vue
+++ b/app/client/src/components/ResultsTable.vue
@@ -51,28 +51,25 @@
 import { defineComponent } from 'vue';
 import { mapState } from 'vuex';
 import { VBTooltip } from 'bootstrap-vue-3';
-import { addRowspan, getRGB, verbalProb } from '../utils';
+import {
+  addRowspan, getRGB, tooltipLine,
+} from '../utils';
 
 export default defineComponent({
   name: 'ResultsTable',
   directives: {
     'b-tooltip': VBTooltip,
   },
-  data() {
-    return {
-      tableData: this.generateTableData(),
-    };
-  },
   methods: {
     getRGB,
-    verbalProb,
+    tooltipLine,
     getTooltipText(data: Record<string, number>) {
       const firstLine = 'Probability of resistance to:';
-      const pen = ['Penicillin: ', this.verbalProb(data.Penicillin, 'Penicillin'), ' <small>(', data.Penicillin, ')</small>'].join('');
-      const chlor = ['Chloramphenicol: ', this.verbalProb(data.Chloramphenicol, 'Chloramphenicol'), ' <small>(', data.Chloramphenicol, ')</small>'].join('');
-      const ery = ['Erythromycin: ', this.verbalProb(data.Erythromycin, 'Erythromycin'), ' <small>(', data.Erythromycin, ')</small>'].join('');
-      const tetra = ['Tetracycline: ', this.verbalProb(data.Tetracycline, 'Tetracycline'), ' <small>(', data.Tetracycline, ')</small>'].join('');
-      const cotrim = ['Cotrim: ', this.verbalProb(data.Trim_sulfa, 'Cotrim'), ' <small>(', data.Trim_sulfa, ')</small>'].join('');
+      const pen = this.tooltipLine('Penicillin', data.Penicillin);
+      const chlor = this.tooltipLine('Chloramphenicol', data.Chloramphenicol);
+      const ery = this.tooltipLine('Erythromycin', data.Erythromycin);
+      const tetra = this.tooltipLine('Tetracycline', data.Tetracycline);
+      const cotrim = this.tooltipLine('Cotrim', data.Trim_sulfa);
       return [firstLine, pen, chlor, ery, tetra, cotrim].join('<br/>');
     },
     getCluster(sample: string) {
@@ -85,49 +82,30 @@ export default defineComponent({
     getNetwork() {
       return (this.analysisStatus.network === 'finished') ? '\u2714' : this.analysisStatus.network;
     },
-    generateTableData() {
-      if (this.results) {
-        const samples = this.results.perIsolate;
-        const items: Array<Record<string, string>> = [];
-        Object.keys(samples).forEach((sample) => {
-          items.push({
-            Hash: samples[sample].hash,
-            Filename: samples[sample].filename,
-            Sketch: (samples[sample].sketch) ? '\u2714' : 'processing',
-            AMR: samples[sample].amr ? samples[sample].amr : 'processing',
-            Cluster: this.submitStatus === 'submitted' ? this.getCluster(sample) : '',
-            Microreact: this.submitStatus === 'submitted' ? this.getMicroreact() : '',
-            Network: this.submitStatus === 'submitted' ? this.getNetwork() : '',
-          });
-        });
-        const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
-        if (this.analysisStatus.assign === 'finished') {
-          // adding a rowspan property to merge microreact/ network cells from same cluster
-          const tableRowspan = addRowspan(tableSorted);
-          return tableRowspan;
-        }
-        return tableSorted;
-      }
-      return null;
-    },
   },
   computed: {
     ...mapState(['results', 'submitStatus', 'analysisStatus']),
-  },
-  mounted() {
-    this.tableData = this.generateTableData();
-  },
-  watch: {
-    results: {
-      handler() {
-        this.tableData = this.generateTableData();
-      },
-      deep: true,
-    },
-    analysisStatus: {
-      handler() {
-        this.tableData = this.generateTableData();
-      },
+    tableData() {
+      const samples = this.results.perIsolate;
+      const items: Array<Record<string, string>> = [];
+      Object.keys(samples).forEach((sample) => {
+        items.push({
+          Hash: samples[sample].hash,
+          Filename: samples[sample].filename,
+          Sketch: (samples[sample].sketch) ? '\u2714' : 'processing',
+          AMR: samples[sample].amr ? samples[sample].amr : 'processing',
+          Cluster: this.submitStatus === 'submitted' ? this.getCluster(sample) : '',
+          Microreact: this.submitStatus === 'submitted' ? this.getMicroreact() : '',
+          Network: this.submitStatus === 'submitted' ? this.getNetwork() : '',
+        });
+      });
+      const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
+      if (this.analysisStatus.assign === 'finished') {
+        // adding a rowspan property to merge microreact/ network cells from same cluster
+        const tableRowspan = addRowspan(tableSorted);
+        return tableRowspan;
+      }
+      return tableSorted;
     },
   },
 });

--- a/app/client/src/components/ResultsTable.vue
+++ b/app/client/src/components/ResultsTable.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <table class="table">
+      <thead>
+        <th>Filename</th>
+        <th>Sketch</th>
+        <th>AMR</th>
+        <th>Cluster</th>
+        <th>Microreact</th>
+        <th>Network</th>
+      </thead>
+      <tbody v-if="tableData">
+        <tr v-for="sample in tableData" :key="sample.Filename">
+          <td>{{sample.Filename}}</td>
+          <td :class="(sample.Sketch === '\u2714') ? 'checkmark' : 'processing'">
+            {{(sample.Sketch === '\u2714') ? sample.Sketch : 'processing'}}
+          </td>
+          <td v-if="sample.AMR === 'processing'" class="processing">{{sample.AMR}}</td>
+          <td v-else>
+            <span v-b-tooltip.hover :title="getTooltipText(sample.AMR)">
+              <b :style="{color: getRGB(sample.AMR.Penicillin, 'Penicillin')}">P</b>
+              <b :style="{color: getRGB(sample.AMR.Chloramphenicol, 'Chloramphenicol')}">C</b>
+              <b :style="{color: getRGB(sample.AMR.Erythromycin, 'Erythromycin')}">E</b>
+              <b :style="{color: getRGB(sample.AMR.Tetracycline, 'Tetracycline')}">T<sub>E
+              </sub></b>
+              <b :style="{color: getRGB(sample.AMR.Trim_sulfa, 'Cotrim')}">S<sub>XT</sub></b>
+            </span>
+          </td>
+          <td :class="(typeof sample.Cluster === 'number') ? '' : 'processing'">
+            {{sample.Cluster}}
+          </td>
+          <td v-if="sample.Rowspan !== 0"
+          style="vertical-align : middle;"
+          :rowspan="sample.Rowspan"
+          :class="(sample.Microreact === '\u2714')? 'checkmark' : 'processing'">
+            {{sample.Microreact}}
+          </td>
+          <td v-if="sample.Rowspan !== 0"
+          style="vertical-align : middle;"
+          :rowspan="sample.Rowspan"
+          :class="(sample.Network === '\u2714') ? 'checkmark' : 'processing'">
+            {{sample.Network}}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang='ts'>
+import { defineComponent } from 'vue';
+import { mapState } from 'vuex';
+import { VBTooltip } from 'bootstrap-vue-3';
+import { addRowspan, getRGB, verbalProb } from '../utils';
+
+export default defineComponent({
+  name: 'ResultsTable',
+  directives: {
+    'b-tooltip': VBTooltip,
+  },
+  data() {
+    return {
+      tableData: this.generateTableData(),
+    };
+  },
+  methods: {
+    getRGB,
+    verbalProb,
+    getTooltipText(data: Record<string, number>) {
+      const firstLine = 'Probability of resistance to:';
+      const pen = ['Penicillin: ', this.verbalProb(data.Penicillin, 'Penicillin'), ' <small>(', data.Penicillin, ')</small>'].join('');
+      const chlor = ['Chloramphenicol: ', this.verbalProb(data.Chloramphenicol, 'Chloramphenicol'), ' <small>(', data.Chloramphenicol, ')</small>'].join('');
+      const ery = ['Erythromycin: ', this.verbalProb(data.Erythromycin, 'Erythromycin'), ' <small>(', data.Erythromycin, ')</small>'].join('');
+      const tetra = ['Tetracycline: ', this.verbalProb(data.Tetracycline, 'Tetracycline'), ' <small>(', data.Tetracycline, ')</small>'].join('');
+      const cotrim = ['Cotrim: ', this.verbalProb(data.Trim_sulfa, 'Cotrim'), ' <small>(', data.Trim_sulfa, ')</small>'].join('');
+      return [firstLine, pen, chlor, ery, tetra, cotrim].join('<br/>');
+    },
+    getCluster(sample: string) {
+      return (this.results.perIsolate[sample].cluster
+        ? this.results.perIsolate[sample].cluster : this.analysisStatus.assign);
+    },
+    getMicroreact() {
+      return (this.analysisStatus.microreact === 'finished') ? '\u2714' : this.analysisStatus.microreact;
+    },
+    getNetwork() {
+      return (this.analysisStatus.network === 'finished') ? '\u2714' : this.analysisStatus.network;
+    },
+    generateTableData() {
+      if (this.results) {
+        const samples = this.results.perIsolate;
+        const items: Array<Record<string, string>> = [];
+        Object.keys(samples).forEach((sample) => {
+          items.push({
+            Hash: samples[sample].hash,
+            Filename: samples[sample].filename,
+            Sketch: (samples[sample].sketch) ? '\u2714' : 'processing',
+            AMR: samples[sample].amr ? samples[sample].amr : 'processing',
+            Cluster: this.submitStatus === 'submitted' ? this.getCluster(sample) : '',
+            Microreact: this.submitStatus === 'submitted' ? this.getMicroreact() : '',
+            Network: this.submitStatus === 'submitted' ? this.getNetwork() : '',
+          });
+        });
+        const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
+        if (this.analysisStatus.assign === 'finished') {
+          // adding a rowspan property to merge microreact/ network cells from same cluster
+          const tableRowspan = addRowspan(tableSorted);
+          return tableRowspan;
+        }
+        return tableSorted;
+      }
+      return null;
+    },
+  },
+  computed: {
+    ...mapState(['results', 'submitStatus', 'analysisStatus']),
+  },
+  mounted() {
+    this.tableData = this.generateTableData();
+  },
+  watch: {
+    results: {
+      handler() {
+        this.tableData = this.generateTableData();
+      },
+      deep: true,
+    },
+    analysisStatus: {
+      handler() {
+        this.tableData = this.generateTableData();
+      },
+    },
+  },
+});
+</script>

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -55,3 +55,34 @@
 .progress-bar {
     background-color: #42b983;
 }
+
+.checkmark {
+    color: green;
+}
+
+.processing {
+    color:#a1abb3;
+}
+
+b {
+    font-size: larger;
+    font-weight: 900;
+    text-shadow: 0px 1px, 1px 0px, 1px 1px;
+}
+
+b+b {
+    margin-left: 5px;
+}
+
+.tooltip-inner {
+    max-width: 400px;
+}
+
+small {
+    font-size: x-small;
+}
+
+.table {
+    width: 90%;
+    margin: 24px auto;
+}

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -1,6 +1,6 @@
 .btn-standard{
     color:#fff;
-    background-color:#9099a0;
+    background-color:#42b983;
     border-color:rgba(0,0,0,0.2);
     padding:0px 12px;
     margin: 6px;
@@ -16,7 +16,7 @@
 
 .btn-standard:hover{
     color:#fff;
-    background-color:#42b983;
+    background-color:#2e855e;
     border-color:rgba(0,0,0,0.2);
     text-decoration: none;
 }

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -22,7 +22,13 @@ export default {
     }
   },
   setIsolateValue(state: RootState, input: IsolateValue) {
-    state.results.perIsolate[input.hash][input.type] = input.result;
+    let results = null;
+    if (input.type === 'amr') {
+      results = JSON.parse(input.result);
+    } else {
+      results = input.result;
+    }
+    state.results.perIsolate[input.hash][input.type] = results;
   },
   setProjectHash(state: RootState, phash: string) {
     state.projectHash = phash;

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -1,11 +1,13 @@
 type Dict<T> = Record<string, T>
 
+export type AMR = Dict<number | string | boolean>
+
 export interface Isolate {
     hash?: string
     filename?: string
-    amr?: string
+    amr?: AMR
     sketch?: string
-    cluster?: string
+    cluster?: number | string
 }
 
 export interface Versions {

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -1,0 +1,106 @@
+export function addRowspan(tableSorted: Record<string, string | number>[]) {
+  // extract cluster numbers
+  const clusters = tableSorted.map((a) => a.Cluster);
+  // get counts of individual clusters
+  const counts = {} as Record<number | string, number>;
+  clusters.forEach((num) => {
+    counts[num] = counts[num] ? counts[num] + 1 : 1;
+  });
+  // generate list of rowspans to be added to table
+  const rowspan = [] as number[];
+  Object.values(counts).forEach((num) => {
+    if (num === 1) {
+      rowspan.push(1);
+    } else {
+      rowspan.push(num);
+      for (let i = 0; i < (num - 1); i += 1) {
+        rowspan.push(0);
+      }
+    }
+  });
+  // map rowspans to hashes
+  const hashes = tableSorted.map((a) => a.Hash);
+  const rowspanMap = {} as Record<string, number>;
+  hashes.forEach((hash, i) => {
+    rowspanMap[hash] = rowspan[i];
+  });
+  // add rowspans to table
+  const tableRowspan = tableSorted.map((obj) => ({ ...obj, Rowspan: rowspanMap[obj.Hash] }));
+  return tableRowspan;
+}
+
+export function getRGB(value: string | number, antibiotic: string) {
+  // Translate probabilities into colours, depending on antibiotic
+  if (value === 'processing') {
+    return 'rgb(50, 168, 82)';
+  }
+  let prob = 0;
+  if (antibiotic === 'Penicillin' || antibiotic === 'Cotrim') {
+    // achieve more colourchanges towards the extremes 0&1
+    prob = 0.07 * Math.log((Number(value) + 0.0008) / (1 - 0.9992 * Number(value))) + 0.499944067;
+  } else if (antibiotic === 'Chloramphenicol' || antibiotic === 'Tetracycline') {
+    // achieve more changes around .5
+    prob = (Math.exp(40 * Number(value) - 20)) / (1 + Math.exp(40 * Number(value) - 20));
+  } else if (antibiotic === 'Erythromycin') {
+    prob = Number(value);
+  }
+  // set targeted colours for values 0 and 1
+  const target0 = { r: 196, g: 212, b: 245 };
+  const target1 = { r: 2, g: 57, b: 168 };
+  const r = Math.round(target0.r - (prob * (target0.r - target1.r)));
+  const g = Math.round(target0.g - (prob * (target0.g - target1.g)));
+  const b = Math.round(target0.b - (prob * (target0.b - target1.b)));
+  return ['rgb(', r, ',', g, ',', b, ')'].join('');
+}
+export function verbalProb(prob: number, antibiotic: string) {
+  // Translate probabilities into words, depending on antibiotic
+  let word = prob.toString();
+  if (antibiotic === 'Penicillin') {
+    if (prob >= 0.9) {
+      word = 'Highly likely';
+    } else if (prob >= 0.75) {
+      word = 'Very good chance';
+    } else if (prob >= 0.5) {
+      word = 'Probably';
+    } else if (prob >= 0.4) {
+      word = 'Probably not';
+    } else if (prob >= 0.2) {
+      word = 'Unlikely';
+    } else if (prob < 0.2) { word = 'Highly unlikely'; }
+  } else if (antibiotic === 'Chloramphenicol') {
+    if (prob >= 0.55) {
+      word = 'Probably';
+    } else if (prob >= 0.5) {
+      word = 'Unsure';
+    } else if (prob < 0.5) {
+      word = 'Highly unlikely';
+    }
+  } else if (antibiotic === 'Erythromycin') {
+    if (prob >= 0.5) {
+      word = 'Almost certainly';
+    } else if (prob >= 0.2) {
+      word = 'Probably not';
+    } else if (prob < 0.2) {
+      word = 'Highly unlikely';
+    }
+  } else if (antibiotic === 'Tetracycline') {
+    if (prob >= 0.5) {
+      word = 'Almost certainly';
+    } else if (prob < 0.5) {
+      word = 'Highly unlikely';
+    }
+  } else if (antibiotic === 'Cotrim') {
+    if (prob >= 0.8) {
+      word = 'Almost certainly';
+    } else if (prob >= 0.7) {
+      word = 'Highly likely';
+    } else if (prob >= 0.5) {
+      word = 'Very good chance';
+    } else if (prob >= 0.2) {
+      word = 'Probably not';
+    } else if (prob < 0.2) {
+      word = 'Unlikely';
+    }
+  }
+  return word;
+}

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -104,3 +104,7 @@ export function verbalProb(prob: number, antibiotic: string) {
   }
   return word;
 }
+
+export function tooltipLine(name: string, num: number) {
+  return `${name}: ${verbalProb(num, name)} <small>(${num})</small>`;
+}

--- a/app/client/src/views/HomeView.vue
+++ b/app/client/src/views/HomeView.vue
@@ -8,6 +8,7 @@
     <DropZone v-if='user' />
     <StartButton v-if='user && filesUploaded' />
     <ProgressBar v-if='user && filesUploaded && submitStatus' />
+    <ResultsTable v-if='user && filesUploaded' class='table'/>
   </div>
 </template>
 
@@ -19,6 +20,7 @@ import GreetingAndLogout from '@/components/GreetingAndLogout.vue';
 import DropZone from '@/components/DropZone.vue';
 import StartButton from '@/components/StartButton.vue';
 import ProgressBar from '@/components/ProgressBar.vue';
+import ResultsTable from '@/components/ResultsTable.vue';
 
 export default defineComponent({
   name: 'HomeView',
@@ -28,6 +30,7 @@ export default defineComponent({
     DropZone,
     StartButton,
     ProgressBar,
+    ResultsTable,
   },
   mounted() {
     this.getUser();

--- a/app/client/src/views/HomeView.vue
+++ b/app/client/src/views/HomeView.vue
@@ -5,7 +5,7 @@
       <LoginPrompt v-if='!user' />
       <GreetingAndLogout v-if='user' />
     </div>
-    <DropZone v-if='user' />
+    <DropZone v-if='user && !submitStatus' />
     <StartButton v-if='user && filesUploaded' />
     <ProgressBar v-if='user && filesUploaded && submitStatus' />
     <ResultsTable v-if='user && filesUploaded' class='table'/>

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom"/>
+/* eslint-disable no-tabs */
 
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'fs';
@@ -46,19 +47,22 @@ test.describe('Logged in Tests', () => {
     await page.dispatchEvent('.dropzone', 'drop', { dataTransfer });
     // Expect count of files to be 2
     await expect(page.locator('.count')).toContainText('2');
-    // Expect files, hashes, AMR and Sketch appearing in file list
-    await expect(page.locator('.uploaded-info')).toContainText('6930_8_13.fa e868c76fec83ee1f69a95bd27b8d5e76 filename 14');
-    await expect(page.locator('.uploaded-info')).toContainText('6930_8_11.fa f3d9b387e311d5ab59a8c08eb3545dbb filename 14');
+    // Expect table to appear
+    await expect(page.locator('table')).toHaveCount(1);
+    // Expect files, hashes, AMR and Sketch appearing in table
+    await page.waitForTimeout(5000);
+    await expect(await page.locator('tr:has-text("6930_8_13.fa")').innerText()).toBe('6930_8_13.fa	✔	PCETE SXT			');
+    await expect(await page.locator('tr:has-text("6930_8_11.fa")').innerText()).toBe('6930_8_11.fa	✔	PCETE SXT			');
     // expect to have a 'start analysis' button after submitting files
     await expect(page.locator('.start-analysis')).toContainText('Start Analysis');
     // Expect to see ProgressBar once button was pressed
     await page.click('text=Start Analysis');
     await expect(page.locator('.progress-bar')).toHaveCount(1);
-    // Expect clusters appearing in file list
-    await expect(page.locator('.uploaded-info')).toContainText('6930_8_13.fa e868c76fec83ee1f69a95bd27b8d5e76 filename 14 7');
-    await expect(page.locator('.uploaded-info')).toContainText('6930_8_11.fa f3d9b387e311d5ab59a8c08eb3545dbb filename 14 24');
-    // Expect all statuses to be updated to finished
+    // Expect all jobs to finish
     await page.waitForTimeout(20000);
     await expect(page.locator('.progress-bar')).toContainText('100.00%');
+    // Expect clusters and arrows for visualisations appearing in table
+    await expect(await page.locator('tr:has-text("6930_8_13.fa")').innerText()).toBe('6930_8_13.fa	✔	PCETE SXT	7	✔	✔');
+    await expect(await page.locator('tr:has-text("6930_8_11.fa")').innerText()).toBe('6930_8_11.fa	✔	PCETE SXT	24	✔	✔');
   });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -50,7 +50,7 @@ test.describe('Logged in Tests', () => {
     // Expect table to appear
     await expect(page.locator('table')).toHaveCount(1);
     // Expect files, hashes, AMR and Sketch appearing in table
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(10000);
     await expect(await page.locator('tr:has-text("6930_8_13.fa")').innerText()).toBe('6930_8_13.fa	✔	PCETE SXT			');
     await expect(await page.locator('tr:has-text("6930_8_11.fa")').innerText()).toBe('6930_8_11.fa	✔	PCETE SXT			');
     // expect to have a 'start analysis' button after submitting files

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -78,7 +78,7 @@ describe('ResultsTable complete', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  test('generateTableData returns table data', () => {
+  test('tableData generates table data', () => {
     const expectedTable = [
       {
         Hash: 'hash2',
@@ -132,7 +132,7 @@ describe('ResultsTable complete', () => {
         Rowspan: 0,
       },
     ];
-    expect(wrapper.vm.generateTableData()).toEqual(expectedTable);
+    expect(wrapper.vm.tableData).toEqual(expectedTable);
   });
 
   test('getTooltipText generates tooltip text', () => {
@@ -248,68 +248,5 @@ describe('ResultsTable incomplete', () => {
     expect(cells[3].text()).toBe('started');
     expect(cells[4].text()).toBe('waiting');
     expect(cells[5].text()).toBe('waiting');
-  });
-
-  it('watcher update tableData', () => {
-    const updatedResults = {
-      perIsolate: {
-        hash1: {
-          hash: 'hash1',
-          filename: 'example1.fa',
-          sketch: 'sketch',
-          cluster: 7,
-          amr: {
-            filename: 'example1.fa',
-            Penicillin: 0.892,
-            Chloramphenicol: 0.39,
-            Erythromycin: 0.151,
-            Tetracycline: 0.453,
-            Trim_sulfa: 0.974,
-          },
-        },
-        hash2: {
-          hash: 'hash2',
-          filename: 'example2.fa',
-          sketch: 'sketch',
-          cluster: 3,
-          amr: {
-            filename: 'example2.fa',
-            Penicillin: 0.892,
-            Chloramphenicol: 0.39,
-            Erythromycin: 0.151,
-            Tetracycline: 0.453,
-            Trim_sulfa: 0.974,
-          },
-        },
-        hash3: {
-          hash: 'hash3',
-          filename: 'example3.fa',
-          sketch: 'sketch',
-          cluster: 7,
-          amr: {
-            filename: 'example3.fa',
-            Penicillin: 0.892,
-            Chloramphenicol: 0.39,
-            Erythromycin: 0.151,
-            Tetracycline: 0.453,
-            Trim_sulfa: 0.974,
-          },
-        },
-      },
-    };
-    const updatedAnalysisStatus = {
-      assign: 'finished',
-      microreact: 'started',
-      network: 'queueing',
-    };
-    const updatedResultsSpy = jest.spyOn(wrapper.vm, 'generateTableData');
-    expect(updatedResultsSpy).toHaveBeenCalledTimes(0);
-    (wrapper.vm.$options.watch?.results as any).handler.call(wrapper.vm, updatedResults);
-    expect(updatedResultsSpy).toHaveBeenCalledTimes(1);
-    (wrapper.vm.$options.watch?.analysisStatus as any).handler.call(
-      wrapper.vm,
-      updatedAnalysisStatus,
-    );
-    expect(updatedResultsSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -1,0 +1,315 @@
+import ResultsTable from '@/components/ResultsTable.vue';
+import { mount } from '@vue/test-utils';
+import { RootState } from '@/store/state';
+import Vuex from 'vuex';
+import { mockRootState } from '../../mocks';
+
+describe('ResultsTable complete', () => {
+  const mockTooltipText = 'Probability of resistance to:<br/>Penicillin: Very good chance <small>(0.892)</small><br/>Chloramphenicol: Highly unlikely <small>(0.39)</small><br/>Erythromycin: Highly unlikely <small>(0.151)</small><br/>Tetracycline: Highly unlikely <small>(0.453)</small><br/>Cotrim: Almost certainly <small>(0.974)</small>';
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      user: {
+        name: 'Jane',
+        id: '543653d45',
+        provider: 'google',
+      },
+      submitStatus: 'submitted',
+      analysisStatus: {
+        assign: 'finished',
+        microreact: 'finished',
+        network: 'finished',
+      },
+      results: {
+        perIsolate: {
+          hash1: {
+            hash: 'hash1',
+            filename: 'example1.fa',
+            sketch: 'sketch',
+            cluster: 7,
+            amr: {
+              filename: 'example1.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+          hash2: {
+            hash: 'hash2',
+            filename: 'example2.fa',
+            sketch: 'sketch',
+            cluster: 3,
+            amr: {
+              filename: 'example2.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+          hash3: {
+            hash: 'hash3',
+            filename: 'example3.fa',
+            sketch: 'sketch',
+            cluster: 7,
+            amr: {
+              filename: 'example3.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+        },
+      },
+    }),
+  });
+  const wrapper = mount(ResultsTable, {
+    global: {
+      plugins: [store],
+    },
+
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  test('generateTableData returns table data', () => {
+    const expectedTable = [
+      {
+        Hash: 'hash2',
+        Filename: 'example2.fa',
+        Sketch: '\u2714',
+        AMR: {
+          filename: 'example2.fa',
+          Penicillin: 0.892,
+          Chloramphenicol: 0.39,
+          Erythromycin: 0.151,
+          Tetracycline: 0.453,
+          Trim_sulfa: 0.974,
+        },
+        Cluster: 3,
+        Microreact: '\u2714',
+        Network: '\u2714',
+        Rowspan: 1,
+      },
+      {
+        Hash: 'hash1',
+        Filename: 'example1.fa',
+        Sketch: '\u2714',
+        AMR: {
+          filename: 'example1.fa',
+          Penicillin: 0.892,
+          Chloramphenicol: 0.39,
+          Erythromycin: 0.151,
+          Tetracycline: 0.453,
+          Trim_sulfa: 0.974,
+        },
+        Cluster: 7,
+        Microreact: '\u2714',
+        Network: '\u2714',
+        Rowspan: 2,
+      },
+      {
+        Hash: 'hash3',
+        Filename: 'example3.fa',
+        Sketch: '\u2714',
+        AMR: {
+          filename: 'example3.fa',
+          Penicillin: 0.892,
+          Chloramphenicol: 0.39,
+          Erythromycin: 0.151,
+          Tetracycline: 0.453,
+          Trim_sulfa: 0.974,
+        },
+        Cluster: 7,
+        Microreact: '\u2714',
+        Network: '\u2714',
+        Rowspan: 0,
+      },
+    ];
+    expect(wrapper.vm.generateTableData()).toEqual(expectedTable);
+  });
+
+  test('getTooltipText generates tooltip text', () => {
+    const mockAMR = {
+      Penicillin: 0.892,
+      Chloramphenicol: 0.39,
+      Erythromycin: 0.151,
+      Tetracycline: 0.453,
+      Trim_sulfa: 0.974,
+    };
+    expect(wrapper.vm.getTooltipText(mockAMR)).toBe(mockTooltipText);
+  });
+
+  test('results are displayed in the table', () => {
+    // 6 headers exist
+    const headers = wrapper.findAll('th');
+    expect(headers.length).toBe(6);
+    // 3 rows exist
+    const rows = wrapper.findAll('tr');
+    expect(rows.length).toBe(3);
+    // 16 cells exist (3x6 minus two merged cells)
+    const cells = wrapper.findAll('td');
+    expect(cells.length).toBe(16);
+    // first cell in each row displays filenames
+    expect(cells[0].text()).toBe('example2.fa');
+    expect(cells[6].text()).toBe('example1.fa');
+    expect(cells[12].text()).toBe('example3.fa');
+    // microreact & network cells from same cluster are merged
+    expect(cells[10].attributes('rowspan')).toBe('2');
+    expect(cells[11].attributes('rowspan')).toBe('2');
+    // AMR cells have tooltip
+    const amrCells = wrapper.findAll('span');
+    expect(amrCells.length).toBe(3);
+    expect(amrCells[0].attributes('data-bs-original-title')).toBe(mockTooltipText);
+  });
+});
+
+describe('ResultsTable incomplete', () => {
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      user: {
+        name: 'Jane',
+        id: '543653d45',
+        provider: 'google',
+      },
+      submitStatus: 'submitted',
+      analysisStatus: {
+        assign: 'started',
+        microreact: 'waiting',
+        network: 'waiting',
+      },
+      results: {
+        perIsolate: {
+          hash1: {
+            hash: 'hash1',
+            filename: 'example1.fa',
+            sketch: 'sketch',
+            amr: {
+              filename: 'example1.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+          hash2: {
+            hash: 'hash2',
+            filename: 'example2.fa',
+            sketch: 'sketch',
+            amr: {
+              filename: 'example2.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+          hash3: {
+            hash: 'hash3',
+            filename: 'example3.fa',
+            sketch: 'sketch',
+            amr: {
+              filename: 'example3.fa',
+              Penicillin: 0.892,
+              Chloramphenicol: 0.39,
+              Erythromycin: 0.151,
+              Tetracycline: 0.453,
+              Trim_sulfa: 0.974,
+            },
+          },
+        },
+      },
+    }),
+  });
+  const wrapper = mount(ResultsTable, {
+    global: {
+      plugins: [store],
+    },
+
+  });
+
+  test('results are displayed in the table', () => {
+    const cells = wrapper.findAll('td');
+    // cells not yet merged
+    expect(cells.length).toBe(18);
+    // filenames not yet sorted by cluster
+    expect(cells[0].text()).toBe('example1.fa');
+    expect(cells[6].text()).toBe('example2.fa');
+    expect(cells[12].text()).toBe('example3.fa');
+    // cluster, microreact and network cells show analysis status
+    expect(cells[3].text()).toBe('started');
+    expect(cells[4].text()).toBe('waiting');
+    expect(cells[5].text()).toBe('waiting');
+  });
+
+  it('watcher update tableData', () => {
+    const updatedResults = {
+      perIsolate: {
+        hash1: {
+          hash: 'hash1',
+          filename: 'example1.fa',
+          sketch: 'sketch',
+          cluster: 7,
+          amr: {
+            filename: 'example1.fa',
+            Penicillin: 0.892,
+            Chloramphenicol: 0.39,
+            Erythromycin: 0.151,
+            Tetracycline: 0.453,
+            Trim_sulfa: 0.974,
+          },
+        },
+        hash2: {
+          hash: 'hash2',
+          filename: 'example2.fa',
+          sketch: 'sketch',
+          cluster: 3,
+          amr: {
+            filename: 'example2.fa',
+            Penicillin: 0.892,
+            Chloramphenicol: 0.39,
+            Erythromycin: 0.151,
+            Tetracycline: 0.453,
+            Trim_sulfa: 0.974,
+          },
+        },
+        hash3: {
+          hash: 'hash3',
+          filename: 'example3.fa',
+          sketch: 'sketch',
+          cluster: 7,
+          amr: {
+            filename: 'example3.fa',
+            Penicillin: 0.892,
+            Chloramphenicol: 0.39,
+            Erythromycin: 0.151,
+            Tetracycline: 0.453,
+            Trim_sulfa: 0.974,
+          },
+        },
+      },
+    };
+    const updatedAnalysisStatus = {
+      assign: 'finished',
+      microreact: 'started',
+      network: 'queueing',
+    };
+    const updatedResultsSpy = jest.spyOn(wrapper.vm, 'generateTableData');
+    expect(updatedResultsSpy).toHaveBeenCalledTimes(0);
+    (wrapper.vm.$options.watch?.results as any).handler.call(wrapper.vm, updatedResults);
+    expect(updatedResultsSpy).toHaveBeenCalledTimes(1);
+    (wrapper.vm.$options.watch?.analysisStatus as any).handler.call(
+      wrapper.vm,
+      updatedAnalysisStatus,
+    );
+    expect(updatedResultsSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -64,7 +64,7 @@ describe('Actions', () => {
     expect(mockAxios.history.get[0].url).toEqual(`${config.server_url}/logout`);
   });
 
-  it('processFiles calculates filehash, adds hash & filename to store and calls setIsolateValue', async () => {
+  it('processFiles calculates filehash, adds hash & filename to store and calls setSketch', async () => {
     const commit = jest.fn();
     const file = {
       name: 'sample.fa',

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -34,7 +34,31 @@ describe('mutations', () => {
     mutations.addFile(state, mockFileMetadata);
     expect(state.results.perIsolate.someFileHash).toStrictEqual({ hash: 'someFileHash', filename: 'sampleName.fa' });
   });
-  it('sets perIsolate values', () => {
+  it('sets sketch values', () => {
+    const state = mockRootState({
+      results: {
+        perIsolate: {
+          someFileHash: {
+            hash: 'someFileHash',
+            filename: 'sampleName.fa',
+          },
+        },
+      },
+    });
+    const { SKETCH } = ValueTypes;
+    const mockIsolateValues = {
+      hash: 'someFileHash',
+      type: SKETCH,
+      result: 'sketch_result',
+    };
+    mutations.setIsolateValue(state, mockIsolateValues);
+    expect(state.results.perIsolate.someFileHash).toStrictEqual({
+      hash: 'someFileHash',
+      filename: 'sampleName.fa',
+      sketch: 'sketch_result',
+    });
+  });
+  it('sets AMR values', () => {
     const state = mockRootState({
       results: {
         perIsolate: {
@@ -46,16 +70,16 @@ describe('mutations', () => {
       },
     });
     const { AMR } = ValueTypes;
-    const mockIsolateValues = {
+    const mockAMR = {
       hash: 'someFileHash',
       type: AMR,
-      result: 'amr_result',
+      result: '{ "Penicillin": 0.5, "Chloramphenicol": 0.2 }',
     };
-    mutations.setIsolateValue(state, mockIsolateValues);
+    mutations.setIsolateValue(state, mockAMR);
     expect(state.results.perIsolate.someFileHash).toStrictEqual({
       hash: 'someFileHash',
       filename: 'sampleName.fa',
-      amr: 'amr_result',
+      amr: { Penicillin: 0.5, Chloramphenicol: 0.2 },
     });
   });
   it('sets submitStatus', () => {

--- a/app/client/tests/unit/utils.spec.ts
+++ b/app/client/tests/unit/utils.spec.ts
@@ -1,0 +1,67 @@
+import { addRowspan, getRGB, verbalProb } from '../../src/utils';
+
+describe('util functions', () => {
+  const sortedTable = [
+    { Hash: 'abcdefg', Cluster: 4 },
+    { Hash: 'hijklmn', Cluster: 7 },
+    { Hash: 'opqrstu', Cluster: 7 },
+    { Hash: 'vwxyz', Cluster: 12 },
+  ];
+  const tableRowspan = [
+    { Hash: 'abcdefg', Cluster: 4, Rowspan: 1 },
+    { Hash: 'hijklmn', Cluster: 7, Rowspan: 2 },
+    { Hash: 'opqrstu', Cluster: 7, Rowspan: 0 },
+    { Hash: 'vwxyz', Cluster: 12, Rowspan: 1 },
+  ];
+
+  it('addRowspan adds correct rowspan to table array', () => {
+    const newTable = addRowspan(sortedTable);
+    expect(newTable).toEqual(tableRowspan);
+  });
+
+  it('getRGB generates right RGB', () => {
+    // all extremes match target colours
+    expect(getRGB(0, 'Erythromycin')).toEqual('rgb(196,212,245)');
+    expect(getRGB(1, 'Erythromycin')).toEqual('rgb(2,57,168)');
+    expect(getRGB(0, 'Chloramphenicol')).toEqual('rgb(196,212,245)');
+    expect(getRGB(1, 'Chloramphenicol')).toEqual('rgb(2,57,168)');
+    expect(getRGB(0, 'Penicillin')).toEqual('rgb(196,212,245)');
+    expect(getRGB(1, 'Penicillin')).toEqual('rgb(2,57,168)');
+    // all Antibiotics match intermediate colour at 0.5
+    expect(getRGB(0.5, 'Erythromycin')).toEqual('rgb(99,135,207)');
+    expect(getRGB(0.5, 'Chloramphenicol')).toEqual('rgb(99,135,207)');
+    expect(getRGB(0.5, 'Penicillin')).toEqual('rgb(99,135,207)');
+    // some other values
+    expect(getRGB(0.2, 'Cotrim')).toEqual('rgb(118,150,214)');
+    expect(getRGB(0.4, 'Tetracycline')).toEqual('rgb(193,209,244)');
+    expect(getRGB(0.3, 'Erythromycin')).toEqual('rgb(138,166,222)');
+    // processing status is grey
+    expect(getRGB('processing', 'Erythromycin')).toEqual('rgb(50, 168, 82)');
+  });
+
+  it('verbalProb generates right verbal representation of probability', () => {
+    expect(verbalProb(1, 'Penicillin')).toEqual('Highly likely');
+    expect(verbalProb(0.8, 'Penicillin')).toEqual('Very good chance');
+    expect(verbalProb(0.6, 'Penicillin')).toEqual('Probably');
+    expect(verbalProb(0.45, 'Penicillin')).toEqual('Probably not');
+    expect(verbalProb(0.3, 'Penicillin')).toEqual('Unlikely');
+    expect(verbalProb(0.1, 'Penicillin')).toEqual('Highly unlikely');
+
+    expect(verbalProb(0.8, 'Chloramphenicol')).toEqual('Probably');
+    expect(verbalProb(0.54, 'Chloramphenicol')).toEqual('Unsure');
+    expect(verbalProb(0.3, 'Chloramphenicol')).toEqual('Highly unlikely');
+
+    expect(verbalProb(0.8, 'Erythromycin')).toEqual('Almost certainly');
+    expect(verbalProb(0.4, 'Erythromycin')).toEqual('Probably not');
+    expect(verbalProb(0.1, 'Erythromycin')).toEqual('Highly unlikely');
+
+    expect(verbalProb(0.6, 'Tetracycline')).toEqual('Almost certainly');
+    expect(verbalProb(0.4, 'Tetracycline')).toEqual('Highly unlikely');
+
+    expect(verbalProb(0.9, 'Cotrim')).toEqual('Almost certainly');
+    expect(verbalProb(0.75, 'Cotrim')).toEqual('Highly likely');
+    expect(verbalProb(0.6, 'Cotrim')).toEqual('Very good chance');
+    expect(verbalProb(0.4, 'Cotrim')).toEqual('Probably not');
+    expect(verbalProb(0.1, 'Cotrim')).toEqual('Unlikely');
+  });
+});


### PR DESCRIPTION
Added the results table that displays:
- the webworker results (sketching successfull, AMR results with tooltip) once they are processed
- after clicking the submit button the job statuses for cluster assignment and microreact & network visualisations appear.
- once results are finished, clusters appear in the table. Microreact/Network only display a checkmark so far, this will be replaced in the next PR by buttons to download the results.
Once clusters are available, the table sorts by cluster and microreact/network cells from the same cluster merge (since we will only have 1 button per cluster for these).

I am a bit unsure about the watchers. Without them, the table content would not update, but I am wondering if this approach is a bit computaionally expensive? Do you have any ideas to make that more efficient?

The utils functions might seem a bit complicated. Since the raw AMR results are not very intuitive to interpret, John and I had discussed approaches to translate them into a verbal representation and also to convert them into colours (light for low probabilities, darker for high probabilities). Since the translation differs by antibiotic (due to the different models/ model performances), the functions are so long and heavy on if/else statements... Maybe this could be moved to the C++/wasm code to have a clearer separation between the research side and the website code?