### PR TITLE
Add Buttons to get visualisation results 

### DIFF
--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -39,7 +39,7 @@ jobs:
 #      uses: mxschmitt/action-tmate@v3
     - name: Run e2e tests
       env:
-      MICROREACT_TOKEN: ${{ secrets.MICROREACT_TOKEN }}
+        MICROREACT_TOKEN: ${{ secrets.MICROREACT_TOKEN }}
       working-directory: ./app/client
       run: npx playwright test
     - name: Stop all components

--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -38,6 +38,8 @@ jobs:
 #    - name: tmate session
 #      uses: mxschmitt/action-tmate@v3
     - name: Run e2e tests
+      env:
+      MICROREACT_TOKEN: ${{ secrets.MICROREACT_TOKEN }}
       working-directory: ./app/client
       run: npx playwright test
     - name: Stop all components

--- a/app/client/src/apiService.ts
+++ b/app/client/src/apiService.ts
@@ -65,6 +65,9 @@ export class APIService<S extends string, E extends string> implements API<S, E>
 
     withError = (type: E) => {
       this._onError = (failure: ResponseFailure) => {
+        if (APIService.getFirstErrorFromFailure(failure).error === 'Wrong Token') {
+          this._commit('setToken', null);
+        }
         this._commit(type, APIService.getFirstErrorFromFailure(failure));
       };
       return this;

--- a/app/client/src/components/DownloadZip.vue
+++ b/app/client/src/components/DownloadZip.vue
@@ -2,7 +2,7 @@
   <button
   @click='onClick()'
   class="btn btn-block btn-standard btn-download">
-    Download files as .zip
+    Download zip file
   </button>
 </template>
 
@@ -11,7 +11,7 @@ import { defineComponent } from 'vue';
 import { mapGetters, mapState, mapActions } from 'vuex';
 
 export default defineComponent({
-  name: 'DownloadMicroreactZip',
+  name: 'DownloadZip',
   props: ['type', 'cluster'],
   methods: {
     ...mapActions(['getZip']),

--- a/app/client/src/components/DownloadZip.vue
+++ b/app/client/src/components/DownloadZip.vue
@@ -1,0 +1,29 @@
+<template>
+  <button
+  @click='onClick()'
+  class="btn btn-block btn-standard btn-download">
+    Download files as .zip
+  </button>
+</template>
+
+<script lang='ts'>
+import { defineComponent } from 'vue';
+import { mapGetters, mapState, mapActions } from 'vuex';
+
+export default defineComponent({
+  name: 'DownloadMicroreactZip',
+  props: ['type', 'cluster'],
+  methods: {
+    ...mapActions(['getZip']),
+    async onClick() {
+      this.getZip({ type: this.type, cluster: this.cluster });
+    },
+  },
+  computed: {
+    ...mapGetters([
+      'uniqueClusters',
+    ]),
+    ...mapState(['projectHash']),
+  },
+});
+</script>

--- a/app/client/src/components/GenerateMicroreactURL.vue
+++ b/app/client/src/components/GenerateMicroreactURL.vue
@@ -10,15 +10,15 @@
       </button>
 
       <button
-        v-if='microreactToken && !results.perCluster[cluster]?.microreactURL'
-        @click='getMicroreactURL(cluster)'
+        v-if='tokenAvailable'
+        @click='buildMicroreactURL(cluster)'
         class='btn btn-block btn-standard btn-download'
       >
         Generate Microreact URL
       </button>
 
       <a
-        v-if='microreactToken && results.perCluster[cluster]?.microreactURL'
+        v-if= 'URLgenerated'
         :href='results.perCluster[cluster]?.microreactURL'
         class='btn btn-block btn-standard btn-download'
         target='_blank'
@@ -80,9 +80,9 @@
 
 <script lang='ts'>
 import { defineComponent } from 'vue';
-import { mapState, mapActions, mapMutations } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import Modal from '@/components/Modal.vue';
-import { BeebopError } from '../types';
+import { BeebopError, Errors } from '../types';
 
 export default defineComponent({
   name: 'GenerateMicroreactURL',
@@ -97,8 +97,7 @@ export default defineComponent({
     };
   },
   methods: {
-    ...mapActions(['getMicroreactURL']),
-    ...mapMutations(['setToken']),
+    ...mapActions(['buildMicroreactURL']),
     showModal() {
       this.isModalVisible = true;
     },
@@ -106,17 +105,19 @@ export default defineComponent({
       this.isModalVisible = false;
     },
     saveToken() {
-      this.setToken(this.token);
-      this.getMicroreactURL(this.cluster);
+      this.buildMicroreactURL({ cluster: this.cluster, token: this.token });
     },
   },
   computed: {
     ...mapState(['results', 'microreactToken', 'errors']),
     tokenWasWrong() {
-      if (this.errors.some((e: BeebopError) => e.error === 'Wrong Token')) {
-        return true;
-      }
-      return false;
+      return this.errors.some((e: BeebopError) => e.error === Errors.WRONG_TOKEN);
+    },
+    tokenAvailable() {
+      return this.microreactToken && !this.results.perCluster[this.cluster]?.microreactURL;
+    },
+    URLgenerated() {
+      return this.microreactToken && this.results.perCluster[this.cluster]?.microreactURL;
     },
   },
 });

--- a/app/client/src/components/GenerateMicroreactURL.vue
+++ b/app/client/src/components/GenerateMicroreactURL.vue
@@ -30,14 +30,14 @@
 
     <Modal v-if='isModalVisible' @close='closeModal' class='modalFlex'>
       <template v-if='tokenWasWrong' v-slot:header>
-        Your submitted token seems to be wrong
+        Your submitted token is invalid
       </template>
-      <template v-else v-slot:header> No Token submitted yet </template>
+      <template v-else v-slot:header> No token submitted yet </template>
 
       <template v-if='tokenWasWrong' v-slot:body>
-        <p>It seems that the Token you gave us was wrong.</p>
+        <p>It seems that the token you gave us was wrong.</p>
         <p>
-          Please make sure you are using a correct Token.<br />
+          Please make sure you are using a correct token.<br />
           You can find your token in your
           <a href='https://microreact.org/my-account/settings' target='_blank'>
             Microreact Account Settings</a
@@ -51,11 +51,11 @@
           '
           class='btn btn-block btn-standard btn-download'
         >
-          Save Token
+          Save token
         </button>
       </template>
       <template v-else v-slot:body>
-        <p>You have not submitted a your Microreact Token yet.</p>
+        <p>You have not submitted a your Microreact token yet.</p>
         <p>
           This is needed to generate a microreact URL for you.<br />
           You can find your token in your
@@ -71,7 +71,7 @@
           '
           class='btn btn-block btn-standard btn-download'
         >
-          Save Token
+          Save token
         </button>
       </template>
     </Modal>

--- a/app/client/src/components/GenerateMicroreactURL.vue
+++ b/app/client/src/components/GenerateMicroreactURL.vue
@@ -1,0 +1,123 @@
+<template>
+  <div>
+    <div>
+      <button
+        v-if='!microreactToken'
+        @click='showModal()'
+        class='btn btn-block btn-standard btn-download'
+      >
+        Generate Microreact URL
+      </button>
+
+      <button
+        v-if='microreactToken && !results.perCluster[cluster]?.microreactURL'
+        @click='getMicroreactURL(cluster)'
+        class='btn btn-block btn-standard btn-download'
+      >
+        Generate Microreact URL
+      </button>
+
+      <a
+        v-if='microreactToken && results.perCluster[cluster]?.microreactURL'
+        :href='results.perCluster[cluster]?.microreactURL'
+        class='btn btn-block btn-standard btn-download'
+        target='_blank'
+        rel='noreferrer'
+      >
+        Visit Microreact URL
+      </a>
+    </div>
+
+    <Modal v-if='isModalVisible' @close='closeModal' class='modalFlex'>
+      <template v-if='tokenWasWrong' v-slot:header>
+        Your submitted token seems to be wrong
+      </template>
+      <template v-else v-slot:header> No Token submitted yet </template>
+
+      <template v-if='tokenWasWrong' v-slot:body>
+        <p>It seems that the Token you gave us was wrong.</p>
+        <p>
+          Please make sure you are using a correct Token.<br />
+          You can find your token in your
+          <a href='https://microreact.org/my-account/settings' target='_blank'>
+            Microreact Account Settings</a
+          >.
+        </p>
+        <input v-model='token' placeholder='Microreact  API Token' />
+        <button
+          @click='
+            closeModal();
+            saveToken();
+          '
+          class='btn btn-block btn-standard btn-download'
+        >
+          Save Token
+        </button>
+      </template>
+      <template v-else v-slot:body>
+        <p>You have not submitted a your Microreact Token yet.</p>
+        <p>
+          This is needed to generate a microreact URL for you.<br />
+          You can find your token in your
+          <a href='https://microreact.org/my-account/settings' target='_blank'>
+            Microreact Account Settings</a
+          >.
+        </p>
+        <input v-model='token' placeholder='Microreact  API Token' />
+        <button
+          @click='
+            closeModal();
+            saveToken();
+          '
+          class='btn btn-block btn-standard btn-download'
+        >
+          Save Token
+        </button>
+      </template>
+    </Modal>
+  </div>
+</template>
+
+<script lang='ts'>
+import { defineComponent } from 'vue';
+import { mapState, mapActions, mapMutations } from 'vuex';
+import Modal from '@/components/Modal.vue';
+import { BeebopError } from '../types';
+
+export default defineComponent({
+  name: 'GenerateMicroreactURL',
+  props: ['cluster'],
+  components: {
+    Modal,
+  },
+  data() {
+    return {
+      isModalVisible: false,
+      token: null,
+    };
+  },
+  methods: {
+    ...mapActions(['getMicroreactURL']),
+    ...mapMutations(['setToken']),
+    showModal() {
+      this.isModalVisible = true;
+    },
+    closeModal() {
+      this.isModalVisible = false;
+    },
+    saveToken() {
+      this.setToken(this.token);
+      this.getMicroreactURL(this.cluster);
+    },
+  },
+  computed: {
+    ...mapState(['results', 'microreactToken', 'errors']),
+    tokenWasWrong() {
+      if (this.errors.some((e: BeebopError) => e.error === 'Wrong Token')) {
+        return true;
+      }
+      return false;
+    },
+  },
+});
+</script>

--- a/app/client/src/components/Modal.vue
+++ b/app/client/src/components/Modal.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+  <div class="modal-backdrop fade show">
+  </div>
+  <div class="modal fade show" style="display: block">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <header class="modal-header">
+          <slot name="header"> </slot>
+          <button type="button" class="btn-close" @click="$emit('close')"></button>
+        </header>
+        <section class="modal-body">
+          <slot name="body"> </slot>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'ModalTemplate',
+};
+</script>

--- a/app/client/src/components/ResultsTable.vue
+++ b/app/client/src/components/ResultsTable.vue
@@ -32,14 +32,25 @@
           <td v-if="sample.Rowspan !== 0"
           style="vertical-align : middle;"
           :rowspan="sample.Rowspan"
-          :class="(sample.Microreact === '\u2714')? 'checkmark' : 'processing'">
-            {{sample.Microreact}}
+          :class="(sample.Microreact === 'showButton')? '' : 'processing'">
+            <p v-if="(sample.Microreact !== 'showButton')">{{sample.Microreact}}</p>
+            <DownloadZip
+            v-if="(sample.Microreact === 'showButton')"
+            :type="'microreact'"
+            :cluster="sample.Cluster"/>
+            <GenerateMicroreactURL
+            v-if="(sample.Microreact === 'showButton')"
+            :cluster="sample.Cluster"/>
           </td>
           <td v-if="sample.Rowspan !== 0"
           style="vertical-align : middle;"
           :rowspan="sample.Rowspan"
-          :class="(sample.Network === '\u2714') ? 'checkmark' : 'processing'">
-            {{sample.Network}}
+          :class="(sample.Network === 'showButton') ? '' : 'processing'">
+            <p v-if="(sample.Network !== 'showButton')">{{sample.Network}}</p>
+            <DownloadZip
+            v-if="(sample.Network === 'showButton')"
+            :type="'network'"
+            :cluster="sample.Cluster"/>
           </td>
         </tr>
       </tbody>
@@ -54,11 +65,17 @@ import { VBTooltip } from 'bootstrap-vue-3';
 import {
   addRowspan, getRGB, tooltipLine,
 } from '../utils';
+import DownloadZip from './DownloadZip.vue';
+import GenerateMicroreactURL from './GenerateMicroreactURL.vue';
 
 export default defineComponent({
   name: 'ResultsTable',
   directives: {
     'b-tooltip': VBTooltip,
+  },
+  components: {
+    DownloadZip,
+    GenerateMicroreactURL,
   },
   methods: {
     getRGB,
@@ -77,17 +94,17 @@ export default defineComponent({
         ? this.results.perIsolate[sample].cluster : this.analysisStatus.assign);
     },
     getMicroreact() {
-      return (this.analysisStatus.microreact === 'finished') ? '\u2714' : this.analysisStatus.microreact;
+      return (this.analysisStatus.microreact === 'finished') ? 'showButton' : this.analysisStatus.microreact;
     },
     getNetwork() {
-      return (this.analysisStatus.network === 'finished') ? '\u2714' : this.analysisStatus.network;
+      return (this.analysisStatus.network === 'finished') ? 'showButton' : this.analysisStatus.network;
     },
   },
   computed: {
     ...mapState(['results', 'submitStatus', 'analysisStatus']),
     tableData() {
       const samples = this.results.perIsolate;
-      const items: Array<Record<string, string>> = [];
+      const items: Record<string, string | number>[] = [];
       Object.keys(samples).forEach((sample) => {
         items.push({
           Hash: samples[sample].hash,

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -45,6 +45,13 @@
     text-decoration: none;
 }
 
+.btn-download{
+    padding:3px 6px;
+    margin: 3px;
+    line-height:25px;
+    font-size:1em;
+}
+
 .progress {
     max-width: 500px;
     height: 2rem;

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -125,16 +125,17 @@ export default {
         link.click();
       });
   },
-  async getMicroreactURL(
+  async buildMicroreactURL(
     context: ActionContext<RootState, RootState>,
-    cluster: string | number,
+    data: Record<string, string | number>,
   ) {
-    const { state } = context;
+    const { state, commit } = context;
+    commit('setToken', data.token);
     await api(context)
       .withSuccess('addMicroreactURL')
       .withError('addError')
       .post<ClusterInfo>(`${config.server_url}/microreactURL`, {
-        cluster,
+        cluster: data.cluster,
         projectHash: state.projectHash,
         apiToken: state.microreactToken,
       });

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -98,4 +98,45 @@ export default {
     commit('setSubmitStatus', 'submitted');
     dispatch('startStatusPolling');
   },
+  async getZip(
+    context: ActionContext<RootState, RootState>,
+    data: Record<string, string | number>,
+  ) {
+    const { state } = context;
+    await axios.post(
+      `${config.server_url}/downloadZip`,
+      {
+        type: data.type,
+        cluster: data.cluster,
+        projectHash: state.projectHash,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        responseType: 'arraybuffer',
+      },
+    )
+      .then((response) => {
+        const blob = new Blob([response.data], { type: 'application/zip' });
+        const link = document.createElement('a');
+        link.href = window.URL.createObjectURL(blob);
+        link.download = `${data.type}_cluster${data.cluster}.zip`;
+        link.click();
+      });
+  },
+  async getMicroreactURL(
+    context: ActionContext<RootState, RootState>,
+    cluster: string | number,
+  ) {
+    const { state } = context;
+    await api(context)
+      .withSuccess('addMicroreactURL')
+      .withError('addError')
+      .post<ClusterInfo>(`${config.server_url}/microreactURL`, {
+        cluster,
+        projectHash: state.projectHash,
+        apiToken: state.microreactToken,
+      });
+  },
 };

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -9,8 +9,10 @@ export default new Vuex.Store<RootState>({
     errors: [],
     versions: [],
     user: null,
+    microreactToken: null,
     results: {
       perIsolate: {},
+      perCluster: {},
     },
     projectHash: null,
     submitStatus: null,

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -48,4 +48,13 @@ export default {
         .cluster = clusterInfo[element].cluster;
     });
   },
+  addMicroreactURL(state: RootState, URLinfo: Record<string, string>) {
+    state.results.perCluster[URLinfo.cluster] = {
+      cluster: URLinfo.cluster,
+      microreactURL: URLinfo.url,
+    };
+  },
+  setToken(state: RootState, token: string | null) {
+    state.microreactToken = token;
+  },
 };

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -10,6 +10,7 @@ export interface RootState {
   errors: BeebopError[]
   versions: Versions | []
   user: User | null
+  microreactToken: string | null
   results: Results
   submitStatus: string | null
   analysisStatus: AnalysisStatus

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -20,6 +20,7 @@ export type User = Dict<string> | null
 
 export interface Results {
     perIsolate: Dict<Isolate>
+    perCluster: Dict<Dict<string>>
 }
 
 export enum ValueTypes {

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -62,3 +62,7 @@ export interface ResponseSuccess {
     data: unknown;
     errors: null;
 }
+
+export enum Errors {
+    WRONG_TOKEN='Wrong Token',
+}

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -51,8 +51,8 @@ test.describe('Logged in Tests', () => {
     await expect(page.locator('table')).toHaveCount(1);
     // Expect files, hashes, AMR and Sketch appearing in table
     await page.waitForTimeout(10000);
-    await expect(await page.locator('tr:has-text("6930_8_13.fa")').innerText()).toBe('6930_8_13.fa	✔	PCETE SXT			');
-    await expect(await page.locator('tr:has-text("6930_8_11.fa")').innerText()).toBe('6930_8_11.fa	✔	PCETE SXT			');
+    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT']);
+    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT']);
     // expect to have a 'start analysis' button after submitting files
     await expect(page.locator('.start-analysis')).toContainText('Start Analysis');
     // Expect to see ProgressBar once button was pressed
@@ -61,8 +61,21 @@ test.describe('Logged in Tests', () => {
     // Expect all jobs to finish
     await page.waitForTimeout(20000);
     await expect(page.locator('.progress-bar')).toContainText('100.00%');
-    // Expect clusters and arrows for visualisations appearing in table
-    await expect(await page.locator('tr:has-text("6930_8_13.fa")').innerText()).toBe('6930_8_13.fa	✔	PCETE SXT	7	✔	✔');
-    await expect(await page.locator('tr:has-text("6930_8_11.fa")').innerText()).toBe('6930_8_11.fa	✔	PCETE SXT	24	✔	✔');
+    // Expect clusters appearing in table
+    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7']);
+    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24']);
+    // Expect download buttons and button to generate microreact URL to appear
+    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText('Download files as .zip');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText('Generate Microreact URL');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText('Download files as .zip');
+    // on clicking Generate Microreact URL button, modal appears
+    await page.click('text=Generate Microreact URL');
+    await expect(page.locator('.modalFlex')).toContainText('No Token submitted yet');
+    await expect(page.locator('.modalFlex .btn')).toContainText('Save Token');
+    // after submittink microreact token, button turns into link to microreact.org
+    await page.locator('input').fill(process.env.MICROREACT_TOKEN as string);
+    await page.click('text=Save Token');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText('Visit Microreact URL');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toHaveAttribute('href', /https:\/\/microreact.org\/project\/.*-poppunk.*/);
   });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -65,9 +65,9 @@ test.describe('Logged in Tests', () => {
     await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7']);
     await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24']);
     // Expect download buttons and button to generate microreact URL to appear
-    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText('Download files as .zip');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText('Download zip file');
     await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText('Generate Microreact URL');
-    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText('Download files as .zip');
+    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText('Download zip file');
     // on clicking Generate Microreact URL button, modal appears
     await page.click('text=Generate Microreact URL');
     await expect(page.locator('.modalFlex')).toContainText('No Token submitted yet');

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -70,11 +70,11 @@ test.describe('Logged in Tests', () => {
     await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText('Download zip file');
     // on clicking Generate Microreact URL button, modal appears
     await page.click('text=Generate Microreact URL');
-    await expect(page.locator('.modalFlex')).toContainText('No Token submitted yet');
-    await expect(page.locator('.modalFlex .btn')).toContainText('Save Token');
+    await expect(page.locator('.modalFlex')).toContainText('No token submitted yet');
+    await expect(page.locator('.modalFlex .btn')).toContainText('Save token');
     // after submittink microreact token, button turns into link to microreact.org
     await page.locator('input').fill(process.env.MICROREACT_TOKEN as string);
-    await page.click('text=Save Token');
+    await page.click('text=Save token');
     await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText('Visit Microreact URL');
     await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toHaveAttribute('href', /https:\/\/microreact.org\/project\/.*-poppunk.*/);
   });

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -12,7 +12,11 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
     errors: [],
     versions: [],
     user: null,
-    results: { perIsolate: {} },
+    microreactToken: null,
+    results: {
+      perIsolate: {},
+      perCluster: {},
+    },
     submitStatus: null,
     analysisStatus: {
       assign: null, microreact: null, network: null,

--- a/app/client/tests/unit/apiService.spec.ts
+++ b/app/client/tests/unit/apiService.spec.ts
@@ -203,6 +203,27 @@ describe('ApiService', () => {
     expect(commit.mock.calls[0][1]).toStrictEqual({ error: 'OTHER_ERROR' });
   });
 
+  it('resets microreact Token if receiving "Wrong Token" Error', async () => {
+    const mockFailureNoDetail = {
+      data: null,
+      status: 'failure',
+      errors: [{ error: 'Wrong Token' }],
+    };
+
+    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+      .reply(500, mockFailureNoDetail);
+
+    const commit = jest.fn();
+    await api({ commit, rootState } as any)
+      .withError('TEST_TYPE')
+      .post(TEST_ROUTE, TEST_BODY);
+
+    expect(commit.mock.calls[0][0]).toBe('setToken');
+    expect(commit.mock.calls[0][1]).toStrictEqual(null);
+    expect(commit.mock.calls[1][0]).toBe('TEST_TYPE');
+    expect(commit.mock.calls[1][1]).toStrictEqual({ error: 'Wrong Token' });
+  });
+
   it('commits the success response with the specified type on get', async () => {
     mockAxios.onGet(TEST_ROUTE)
       .reply(200, mockSuccess('test data'));

--- a/app/client/tests/unit/components/DownloadZip.spec.ts
+++ b/app/client/tests/unit/components/DownloadZip.spec.ts
@@ -1,0 +1,49 @@
+import DownloadZip from '@/components/DownloadZip.vue';
+import { mount } from '@vue/test-utils';
+import { RootState } from '@/store/state';
+import Vuex from 'vuex';
+import { mockRootState } from '../../mocks';
+
+describe('DownloadZip button', () => {
+  const getZip = jest.fn();
+  const uniqueClusters = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      user: {
+        name: 'Jane',
+        id: '543653d45',
+        provider: 'google',
+      },
+      results: {
+        perIsolate: {
+          someHash: {
+            hash: 'someHash',
+            filename: 'example.fa',
+            sketch: 'sketch',
+          },
+        },
+        perCluster: {},
+      },
+    }),
+    actions: {
+      getZip,
+    },
+    getters: {
+      uniqueClusters,
+    },
+  });
+  const wrapper = mount(DownloadZip, {
+    global: {
+      plugins: [store],
+    },
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+  it('onClick triggers action to download zip data', () => {
+    wrapper.vm.onClick();
+    expect(getZip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/client/tests/unit/components/DropZone.spec.ts
+++ b/app/client/tests/unit/components/DropZone.spec.ts
@@ -28,6 +28,7 @@ describe('Dropzone', () => {
       },
       results: {
         perIsolate: {},
+        perCluster: {},
       },
     }),
     actions: {

--- a/app/client/tests/unit/components/DropZoneActive.spec.ts
+++ b/app/client/tests/unit/components/DropZoneActive.spec.ts
@@ -26,6 +26,7 @@ describe('Dropzone', () => {
       },
       results: {
         perIsolate: {},
+        perCluster: {},
       },
     }),
   });

--- a/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
+++ b/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
@@ -5,8 +5,7 @@ import Vuex from 'vuex';
 import { mockRootState } from '../../mocks';
 
 describe('Generate Microreact URL button with no token submitted', () => {
-  const getMicroreactURL = jest.fn();
-  const setToken = jest.fn();
+  const buildMicroreactURL = jest.fn();
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
@@ -18,10 +17,7 @@ describe('Generate Microreact URL button with no token submitted', () => {
       errors: [],
     }),
     actions: {
-      getMicroreactURL,
-    },
-    mutations: {
-      setToken,
+      buildMicroreactURL,
     },
   });
   const wrapper = mount(GenerateMicroreactURL, {
@@ -101,8 +97,7 @@ describe('Modal shows different text when creating URL already returned wrong to
 });
 
 describe('Submitting token closes modal and saves token', () => {
-  const getMicroreactURL = jest.fn();
-  const setToken = jest.fn();
+  const buildMicroreactURL = jest.fn();
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
@@ -114,10 +109,7 @@ describe('Submitting token closes modal and saves token', () => {
       errors: [],
     }),
     actions: {
-      getMicroreactURL,
-    },
-    mutations: {
-      setToken,
+      buildMicroreactURL,
     },
   });
   const wrapper = mount(GenerateMicroreactURL, {
@@ -136,13 +128,12 @@ describe('Submitting token closes modal and saves token', () => {
     const submitButton = wrapper.findAll('.modalFlex .btn-standard')[0];
     submitButton.trigger('click');
     expect(wrapper.vm.isModalVisible).toBe(false);
-    expect(setToken).toHaveBeenCalledTimes(1);
-    expect(getMicroreactURL).toHaveBeenCalledTimes(1);
+    expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('Generates URL when token is available', () => {
-  const getMicroreactURL = jest.fn();
+  const buildMicroreactURL = jest.fn();
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
@@ -154,7 +145,7 @@ describe('Generates URL when token is available', () => {
       errors: [],
     }),
     actions: {
-      getMicroreactURL,
+      buildMicroreactURL,
     },
   });
   const wrapper = mount(GenerateMicroreactURL, {
@@ -171,7 +162,7 @@ describe('Generates URL when token is available', () => {
     expect(wrapper.findAll('button')).toHaveLength(1);
     const button = wrapper.findAll('button')[0];
     button.trigger('click');
-    expect(getMicroreactURL).toHaveBeenCalledTimes(1);
+    expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
+++ b/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
@@ -1,0 +1,213 @@
+import GenerateMicroreactURL from '@/components/GenerateMicroreactURL.vue';
+import { mount } from '@vue/test-utils';
+import { RootState } from '@/store/state';
+import Vuex from 'vuex';
+import { mockRootState } from '../../mocks';
+
+describe('Generate Microreact URL button with no token submitted', () => {
+  const getMicroreactURL = jest.fn();
+  const setToken = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {},
+      },
+      microreactToken: null,
+      errors: [],
+    }),
+    actions: {
+      getMicroreactURL,
+    },
+    mutations: {
+      setToken,
+    },
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    global: {
+      plugins: [store],
+    },
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  test('on click sets modal visibility to true', () => {
+    expect(wrapper.findAll('button')).toHaveLength(1);
+    expect(wrapper.findAll('Modal')).toHaveLength(0);
+    const button = wrapper.findAll('button')[0];
+    expect(wrapper.vm.isModalVisible).toBe(false);
+    button.trigger('click');
+    expect(wrapper.vm.isModalVisible).toBe(true);
+  });
+});
+
+describe('Modal is visible on isModalVisible: true', () => {
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {},
+      },
+      microreactToken: 'microreact_token',
+      errors: [],
+    }),
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    data() {
+      return {
+        isModalVisible: true,
+      };
+    },
+    global: {
+      plugins: [store],
+    },
+  });
+  test('Modal appears on isModalVisible: true', () => {
+    expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
+    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('No Token submitted yet');
+  });
+});
+
+describe('Modal shows different text when creating URL already returned wrong token error', () => {
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {},
+      },
+      microreactToken: 'microreact_token',
+      errors: [
+        { error: 'Wrong Token' },
+      ],
+    }),
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    data() {
+      return {
+        isModalVisible: true,
+      };
+    },
+    global: {
+      plugins: [store],
+    },
+  });
+  test('Modal appears on isModalVisible: true', () => {
+    expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
+    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('Your submitted token seems to be wrong');
+  });
+});
+
+describe('Submitting token closes modal and saves token', () => {
+  const getMicroreactURL = jest.fn();
+  const setToken = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {},
+      },
+      microreactToken: 'microreact_token',
+      errors: [],
+    }),
+    actions: {
+      getMicroreactURL,
+    },
+    mutations: {
+      setToken,
+    },
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    data() {
+      return {
+        isModalVisible: true,
+        token: 'microreact_token',
+      };
+    },
+    global: {
+      plugins: [store],
+    },
+  } as any);
+  test('Modal appears on isModalVisible: true', () => {
+    expect(wrapper.findAll('.modalFlex .btn-standard')).toHaveLength(1);
+    const submitButton = wrapper.findAll('.modalFlex .btn-standard')[0];
+    submitButton.trigger('click');
+    expect(wrapper.vm.isModalVisible).toBe(false);
+    expect(setToken).toHaveBeenCalledTimes(1);
+    expect(getMicroreactURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Generates URL when token is available', () => {
+  const getMicroreactURL = jest.fn();
+
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {},
+      },
+      microreactToken: 'microreact_token',
+      errors: [],
+    }),
+    actions: {
+      getMicroreactURL,
+    },
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    global: {
+      plugins: [store],
+    },
+  });
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  test('on click triggers action to get URL', () => {
+    expect(wrapper.findAll('button')).toHaveLength(1);
+    const button = wrapper.findAll('button')[0];
+    button.trigger('click');
+    expect(getMicroreactURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Provides link to be redirected to microreact', () => {
+  const store = new Vuex.Store<RootState>({
+    state: mockRootState({
+      results: {
+        perIsolate: {},
+        perCluster: {
+          7: {
+            cluster: '7',
+            microreactURL: 'microreact.org/mock',
+          },
+        },
+      },
+      microreactToken: 'microreact_token',
+      errors: [],
+    }),
+  });
+  const wrapper = mount(GenerateMicroreactURL, {
+    propsData: {
+      cluster: 7,
+    },
+    global: {
+      plugins: [store],
+    },
+  } as any);
+
+  test('does a wrapper exist', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  test('get href from state', () => {
+    expect(wrapper.findAll('button')).toHaveLength(0);
+    expect(wrapper.findAll('a')).toHaveLength(1);
+    const link = wrapper.find('a');
+    expect(link.attributes().href).toBe('microreact.org/mock');
+  });
+});

--- a/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
+++ b/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
@@ -63,7 +63,7 @@ describe('Modal is visible on isModalVisible: true', () => {
   });
   test('Modal appears on isModalVisible: true', () => {
     expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
-    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('No Token submitted yet');
+    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('No token submitted yet');
   });
 });
 
@@ -92,7 +92,7 @@ describe('Modal shows different text when creating URL already returned wrong to
   });
   test('Modal appears on isModalVisible: true', () => {
     expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
-    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('Your submitted token seems to be wrong');
+    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('Your submitted token is invalid');
   });
 });
 

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -64,6 +64,7 @@ describe('ResultsTable complete', () => {
             },
           },
         },
+        perCluster: {},
       },
     }),
   });
@@ -93,8 +94,8 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 3,
-        Microreact: '\u2714',
-        Network: '\u2714',
+        Microreact: 'showButton',
+        Network: 'showButton',
         Rowspan: 1,
       },
       {
@@ -110,8 +111,8 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 7,
-        Microreact: '\u2714',
-        Network: '\u2714',
+        Microreact: 'showButton',
+        Network: 'showButton',
         Rowspan: 2,
       },
       {
@@ -127,8 +128,8 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 7,
-        Microreact: '\u2714',
-        Network: '\u2714',
+        Microreact: 'showButton',
+        Network: 'showButton',
         Rowspan: 0,
       },
     ];
@@ -226,6 +227,7 @@ describe('ResultsTable incomplete', () => {
             },
           },
         },
+        perCluster: {},
       },
     }),
   });

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -28,6 +28,7 @@ describe('StartButton', () => {
             sketch: 'sketch',
           },
         },
+        perCluster: {},
       },
     }),
     actions: {
@@ -79,6 +80,7 @@ describe('StartButton disabled', () => {
             filename: 'example2.fa',
           },
         },
+        perCluster: {},
       },
     }),
   });
@@ -115,6 +117,7 @@ describe('StartButton disabled after submit', () => {
             sketch: 'sketch',
           },
         },
+        perCluster: {},
       },
     }),
   });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -275,16 +275,20 @@ describe('Actions', () => {
     expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
-  it('getMicroreactURL makes axios call and updates results', async () => {
+  it('buildMicroreactURL makes axios call and updates results', async () => {
     const commit = jest.fn();
     const state = mockRootState({
       projectHash: 'randomHash',
     });
     const expResponse = responseSuccess({ cluster: 7, url: 'microreact.org/mock' });
     mockAxios.onPost(`${config.server_url}/microreactURL`).reply(200, expResponse);
-    await actions.getMicroreactURL({ commit, state } as any, 7);
+    await actions.buildMicroreactURL({ commit, state } as any, { cluster: 7, token: 'some_token' });
     expect(mockAxios.history.post[0].url).toEqual(`${config.server_url}/microreactURL`);
     expect(commit.mock.calls[0]).toEqual([
+      'setToken',
+      'some_token',
+    ]);
+    expect(commit.mock.calls[1]).toEqual([
       'addMicroreactURL',
       expResponse.data,
     ]);

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -43,6 +43,7 @@ describe('mutations', () => {
             filename: 'sampleName.fa',
           },
         },
+        perCluster: {},
       },
     });
     const { SKETCH } = ValueTypes;
@@ -67,6 +68,7 @@ describe('mutations', () => {
             filename: 'sampleName.fa',
           },
         },
+        perCluster: {},
       },
     });
     const { AMR } = ValueTypes;
@@ -120,9 +122,24 @@ describe('mutations', () => {
             hash: 'someFileHash2',
           },
         },
+        perCluster: {},
       },
     });
     mutations.setClusters(state, { 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } });
     expect(state.results.perIsolate.someFileHash.cluster).toBe('12');
+  });
+  it('sets MicroreactURL', () => {
+    const state = mockRootState();
+    const mockURLInfo = {
+      cluster: '7',
+      url: 'microreact.org/mock',
+    };
+    mutations.addMicroreactURL(state, mockURLInfo);
+    expect(state.results.perCluster[mockURLInfo.cluster]).toStrictEqual({ cluster: '7', microreactURL: 'microreact.org/mock' });
+  });
+  it('sets Microreact Token', () => {
+    const state = mockRootState();
+    mutations.setToken(state, 'mock_microreact_token');
+    expect(state.microreactToken).toBe('mock_microreact_token');
   });
 });

--- a/app/client/tests/unit/views/HomeView.spec.ts
+++ b/app/client/tests/unit/views/HomeView.spec.ts
@@ -59,6 +59,7 @@ describe('Home', () => {
         },
         results: {
           perIsolate: {},
+          perCluster: {},
         },
       }),
       actions: {
@@ -91,6 +92,7 @@ describe('Home', () => {
             someFileHash: {},
             someFileHash2: {},
           },
+          perCluster: {},
         },
         submitStatus: null,
         analysisStatus: {
@@ -129,6 +131,7 @@ describe('Home', () => {
             someFileHash: {},
             someFileHash2: {},
           },
+          perCluster: {},
         },
         submitStatus: 'submitted',
         analysisStatus: {

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -80,7 +80,43 @@ export const router = (app => {
             res.redirect(config.client_url);
         }
     );
+
+    app.post('/downloadZip',
+        downloadZip);
+
+    app.post('/microreactURL',
+        microreactURL);
+
 })
+
+export async function downloadZip(request, response) {
+    await axios.post(`${config.api_url}/results/zip`,
+        request.body,
+        {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            responseType: 'arraybuffer',
+        })
+        .then(res => response.send(res.data))
+        .catch(function (error) {
+            sendError(response, error);
+          });
+}
+
+export async function microreactURL(request, response) {
+    await axios.post(`${config.api_url}/results/microreact`,
+        request.body,
+        {
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => {response.send(res.data)})
+        .catch(function (error) {
+            sendError(response, error);
+          });
+}
 
 export async function getVersionInfo(request, response) {
     await axios.get(`${config.api_url}/version`)
@@ -98,7 +134,7 @@ export async function runPoppunk(request, response) {
     )
         .then(res => response.send(res.data))
         .catch(function (error) {
-            console.log(error);
+            sendError(response, error);
         });
 }
 
@@ -106,7 +142,7 @@ export async function getStatus(request, response) {
     await axios.get(`${config.api_url}/status/${request.body.hash}`)
         .then(res => response.send(res.data))
         .catch(function (error) {
-            console.log(error);
+            sendError(response, error);
         });
 }
 
@@ -120,7 +156,7 @@ export async function getAssignResult(request, response) {
     })
         .then(res => response.send(res.data))
         .catch(function (error) {
-            console.log(error);
+            sendError(response, error);
         });
 }
 
@@ -136,4 +172,23 @@ const authCheck = (req, res, next) => {
     } else {
         next();
     }
+}
+
+function sendError(response, error) {
+    if (error.response) {
+        response.status(500).send(
+            {
+                status:"failure",
+                errors:[{error: error.response.data.error.errors[0].error, detail: error.response.data.error.errors[0].detail}],
+                data: null
+            })  
+    } else {
+      response.status(500).send(
+        {
+            status:"failure",
+            errors:[{error: 'Could not connect to API', detail: error}],
+            data: null
+        })  
+    }
+    
 }

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -19,6 +19,7 @@ docker run -d --rm --name $NAME_WORKER --network=$NETWORK \
        -v $VOLUME:/beebop/storage \
        mrcide/beebop-py:$API_BRANCH rqworker
 docker run -d --rm --name $NAME_API --network=$NETWORK \
+       --pull always \
        --env=REDIS_HOST="$NAME_REDIS" \
        --env=STORAGE_LOCATION="./storage" \
        --env=DB_LOCATION="./storage/GPS_v4_references" \


### PR DESCRIPTION
The results table now has buttons to
- download microreact and network files as zipped folders
- generate a microreact URL
Once the microreact URL has been generated, the button turns into a link that redirects to the microreact project.

(At the moment the microreact output/ URL is not working properly - despite files/  a valid URL being generated, microreact.org will show 'An unexpected error has occurred.' for most clusters. This also happens when downloading the files and uploading to microreact. I suspect this is an issue with PopPUNK rather than beebop - needs further investigation)