### PR TITLE
Send filehash/name mapping with poppunk request

### DIFF
--- a/app/client/jest.config.js
+++ b/app/client/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.{ts,vue}',
     '!src/main.ts',
-    '!src/components/CytoscapeGraph.vue'
+    '!src/components/CytoscapeGraph.vue',
   ],
 };

--- a/app/client/src/components/GenerateMicroreactURL.vue
+++ b/app/client/src/components/GenerateMicroreactURL.vue
@@ -11,7 +11,7 @@
 
       <button
         v-if='tokenAvailable'
-        @click='buildMicroreactURL(cluster)'
+        @click='buildMicroreactURL({cluster, token: microreactToken})'
         class='btn btn-block btn-standard btn-download'
       >
         Generate Microreact URL

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -94,10 +94,17 @@ small {
     margin: 24px auto;
 }
 
+.cytoscape-graph {
+    height: 100%;
+    max-height: 800px;
+    min-height: 500px;
+    display: flex;
+    flex-direction: column;
+}
+
 #cy {
     width: 100%;
-    min-height: 500px;
-    max-height: 800px;
+    flex-grow: 1;
     border: 1px dashed grey;
     text-align: start;
     margin: auto;
@@ -145,6 +152,14 @@ small {
     border: 1px solid grey;
     border-left: 0;
     padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.tab-pane {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 .nav-tabs {

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -4,7 +4,7 @@ import config from '@/resources/config.json';
 import { Md5 } from 'ts-md5/dist/md5';
 import { RootState } from '@/store/state';
 import {
-  Versions, User, AnalysisStatus, ClusterInfo,
+  Versions, User, AnalysisStatus, ClusterInfo, Dict,
 } from '@/types';
 import { api } from '../apiService';
 
@@ -50,7 +50,7 @@ export default {
     // Also generate a string of ordered hashes and corresponding filenames
     // to be used to generate a projecthash that is unique to this combination
     // of file contents and filenames
-    const filenameMapping = {} as { [key: string]: string | undefined };
+    const filenameMapping = {} as Dict<string | undefined>;
     let mappingOrdered = '';
     Object.keys(state.results.perIsolate).sort().forEach((filehash) => {
       filenameMapping[filehash] = state.results.perIsolate[filehash].filename;
@@ -60,7 +60,7 @@ export default {
     const phash = Md5.hashStr(mappingOrdered);
     commit('setProjectHash', phash);
     // add all sketches to object
-    const jsonSketches = {} as { [key: string]: Record<string, never> };
+    const jsonSketches = {} as Dict<Dict<string>>;
     Object.keys(state.results.perIsolate).forEach((element) => {
       jsonSketches[element] = JSON.parse(state.results.perIsolate[element].sketch as string);
     });

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -50,10 +50,13 @@ export default {
     // Also generate a string of ordered hashes and corresponding filenames
     // to be used to generate a projecthash that is unique to this combination
     // of file contents and filenames
-    const filenameMapping = {} as Dict<string | undefined>;
+    const filenameMapping = {} as Dict<string>;
     let mappingOrdered = '';
     Object.keys(state.results.perIsolate).sort().forEach((filehash) => {
-      filenameMapping[filehash] = state.results.perIsolate[filehash].filename;
+      // disabling this rule here since this should always have a value
+      // since the action can only be triggered when files have been uploaded:
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      filenameMapping[filehash] = state.results.perIsolate[filehash].filename!;
       mappingOrdered += filehash;
       mappingOrdered += state.results.perIsolate[filehash].filename;
     });

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -52,10 +52,18 @@ export default {
     Object.keys(state.results.perIsolate).forEach((element) => {
       jsonSketches[element] = JSON.parse(state.results.perIsolate[element].sketch as string);
     });
+    const filenameMapping = {} as { [key: string]: string | undefined };
+    Object.keys(state.results.perIsolate).forEach((element) => {
+      filenameMapping[element] = state.results.perIsolate[element].filename;
+    });
     const response = await api(context)
       .withError('addError')
       .ignoreSuccess()
-      .post<AnalysisStatus>(`${config.server_url}/poppunk`, { projectHash: phash, sketches: jsonSketches });
+      .post<AnalysisStatus>(`${config.server_url}/poppunk`, {
+        projectHash: phash,
+        sketches: jsonSketches,
+        names: filenameMapping,
+      });
     if (response) {
       commit('setAnalysisStatus', { assign: 'submitted', microreact: 'submitted', network: 'submitted' });
     }

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -1,6 +1,6 @@
 import cytoscape from 'cytoscape';
 
-type Dict<T> = Record<string, T>
+export type Dict<T> = Record<string, T>
 
 export type AMR = Dict<number | string | boolean>
 

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -85,16 +85,18 @@ describe('Actions', () => {
       results: {
         perIsolate: {
           someFileHash: {
+            filename: 'someFilename',
             sketch: '{"14":"12345"}',
           },
           someFileHash2: {
+            filename: 'someFilename2',
             sketch: '{"14":"12345"}',
           },
         },
         perCluster: {},
       },
     });
-    const expectedHash = Md5.hashStr(Object.keys(state.results.perIsolate).sort().join());
+    const expectedHash = Md5.hashStr('someFileHashsomeFilenamesomeFileHash2someFilename2');
     mockAxios.onPost(`${config.server_url}/poppunk`).reply(200, responseSuccess({
       assign: 'job-id', microreact: 'job-id', network: 'job-id',
     }));

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,7 +4,7 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
-API_BRANCH=bacpop-57
+API_BRANCH=bacpop-59
 NAME_WORKER=beebop-py-worker
 PORT=5000
 

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,7 +4,7 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
-API_BRANCH=bacpop-59
+API_BRANCH=bacpop-61
 NAME_WORKER=beebop-py-worker
 PORT=5000
 

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,7 +4,7 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
-API_BRANCH=bacpop-61
+API_BRANCH=bacpop-59
 NAME_WORKER=beebop-py-worker
 PORT=5000
 


### PR DESCRIPTION
This mapping is needed to replace the file hases in the result files with the right filenames.

To do: 

- [x] add filenames to project hash generation to avoid overwriting filenames from another user when file content is the same, but filename differs