### PR TITLE
example test mocking cytoscape

### DIFF
--- a/app/client/tests/unit/components/CytoscapeGraph.spec.ts
+++ b/app/client/tests/unit/components/CytoscapeGraph.spec.ts
@@ -1,7 +1,15 @@
 // Mock the import of cytoscape
-jest.mock('cytoscape', () => jest.fn().mockReturnValue({
-    ready: jest.fn(),
-  }));
+import cytoscape from "cytoscape";
+
+const mockReady = jest.fn();
+const mockGraphMl = jest.fn();
+const mockCytoscape = jest.fn().mockReturnValue({
+  ready: mockReady,
+  graphml: mockGraphMl
+});
+
+jest.mock('cytoscape', () => mockCytoscape);
+
 
 import { mount } from '@vue/test-utils';
 import { RootState } from '@/store/state';
@@ -64,19 +72,69 @@ describe('Component calls cytoscape.ready()', () => {
       getGraphml,
     },
   });
-  const wrapper = mount(CytoscapeGraph, {
-    propsData: {
-      cluster: 2,
-    },
-    global: {
-      plugins: [store],
-    },
-  } as any);
+
+  const getWrapper = () => {
+    return mount(CytoscapeGraph, {
+      propsData: {
+        cluster: 2,
+      },
+      global: {
+        plugins: [store],
+      },
+    } as any);
+  }
+
 
   test('does a wrapper exist', () => {
+    const wrapper = getWrapper();
     expect(wrapper.exists()).toBe(true);
   });
 
-  test('cytoscape.ready() gets called', () => {
+  test('cytoscape methods called as expected', () => {
+    jest.resetAllMocks();
+    getWrapper();
+
+    expect(mockCytoscape).toHaveBeenCalledTimes(1);
+    expect(mockCytoscape.mock.calls[0][0]).toStrictEqual({
+      container: this.$refs.cy as HTMLElement,
+      style: [
+        {
+          selector: 'node',
+          style: {
+            width: '10px',
+            height: '10px',
+            content: 'data(key0)',
+            'font-size': '7px',
+            'background-color': 'darkblue',
+            'border-style': 'solid',
+            'border-color': 'black',
+            'border-width': '1px',
+          },
+        },
+        {
+          selector: 'edge',
+          style: {
+            width: '2px',
+            'line-color': 'steelblue',
+          },
+        },
+      ],
+      layout: {
+        name: 'grid',
+      },
+    });
+    expect(mockReady).toHaveBeenCalledTimes(1);
+
+    // Expect that calling the method passed to ready as a parameter will in turn call graphml
+    const readyParam = mockReady.mock.calls[0][0];
+    readyParam();
+    expect(mockGraphMl).toHaveBeenCalledTimes(2);
+    expect(mockGraphMl.mock.calls[0][0]).toStrictEqual({ layoutBy: 'cose' });
+    expect(mockGraphMl.mock.calls[0][0]).toStrictEqual({
+      graph: {
+        cluster: '2',
+        graph: '<graph></graph>',
+      }
+    });
   });
 });


### PR DESCRIPTION
I had a go at testing that `ready` had been invoked, and that it does what we expect it to. Quite tricky because of there being so many different 3rd party methods being called. 

Also, I think having an arrangement where the wrapper is generated outside any test call, and also having multiple `describe` blocks, makes managing the mocks a little harder. I usually just have one `describe` per module, and create all wrappers in `getWrapper` methods. 