### PR TITLE
Highlight query samples in network graph 

### DIFF
--- a/app/client/src/components/CytoscapeGraph.vue
+++ b/app/client/src/components/CytoscapeGraph.vue
@@ -41,6 +41,18 @@ export default defineComponent({
               'font-size': '7px',
               'background-color': 'darkblue',
               'border-style': 'solid',
+            },
+          },
+          {
+            selector: 'node[ref_query = "query"]',
+            style: {
+              'border-color': 'red',
+              'border-width': '2px',
+            },
+          },
+          {
+            selector: 'node[ref_query = "ref"]',
+            style: {
               'border-color': 'black',
               'border-width': '1px',
             },

--- a/app/client/tests/unit/components/CytoscapeGraph.spec.ts
+++ b/app/client/tests/unit/components/CytoscapeGraph.spec.ts
@@ -97,6 +97,18 @@ describe('CytoscapeGraph', () => {
             'font-size': '7px',
             'background-color': 'darkblue',
             'border-style': 'solid',
+          },
+        },
+        {
+          selector: 'node[ref_query = "query"]',
+          style: {
+            'border-color': 'red',
+            'border-width': '2px',
+          },
+        },
+        {
+          selector: 'node[ref_query = "ref"]',
+          style: {
             'border-color': 'black',
             'border-width': '1px',
           },

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,7 +4,7 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
-API_BRANCH=bacpop-59
+API_BRANCH=bacpop-61
 NAME_WORKER=beebop-py-worker
 PORT=5000
 


### PR DESCRIPTION
Border-colour of query samples should be red to highlight own samples in the network graph.