### PR TITLE
Add lineages to results table

### DIFF
--- a/app/client/src/components/ResultsTable.vue
+++ b/app/client/src/components/ResultsTable.vue
@@ -6,6 +6,19 @@
         <th>Sketch</th>
         <th>AMR</th>
         <th>Cluster</th>
+        <th class="dropdown">
+            <div class="dropdown-toggle"
+            type="button" id="dropdownMenuButton"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
+              Lineage Rank {{rank}}
+            </div>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+              <a class="dropdown-item" id="one" @click="onInput(1)" href="#">Rank 1</a>
+              <a class="dropdown-item" id="two" @click="onInput(2)" href="#">Rank 2</a>
+              <a class="dropdown-item" id="three" @click="onInput(3)" href="#">Rank 3</a>
+            </div>
+        </th>
         <th>Microreact</th>
         <th>Network</th>
       </thead>
@@ -28,6 +41,9 @@
           </td>
           <td :class="(typeof sample.Cluster === 'number') ? '' : 'processing'">
             {{sample.Cluster}}
+          </td>
+          <td :class="(typeof sample.Lineage === 'number') ? '' : 'processing'">
+            {{sample.Lineage}}
           </td>
           <td v-if="sample.Rowspan !== 0"
           style="vertical-align : middle;"
@@ -77,6 +93,11 @@ export default defineComponent({
     DownloadZip,
     GenerateMicroreactURL,
   },
+  data() {
+    return {
+      rank: 1,
+    };
+  },
   methods: {
     getRGB,
     tooltipLine,
@@ -91,13 +112,22 @@ export default defineComponent({
     },
     getCluster(sample: string) {
       return (this.results.perIsolate[sample].cluster
-        ? this.results.perIsolate[sample].cluster : this.analysisStatus.assign);
+        ? this.results.perIsolate[sample].cluster : this.analysisStatus.assignClusters);
+    },
+    getLineage(sample: string, rank: number) {
+      const selectedRank = `rank${rank}`;
+      return (this.results.perIsolate[sample].lineage
+        ? this.results.perIsolate[sample].lineage[selectedRank]
+        : this.analysisStatus.assignLineages);
     },
     getMicroreact() {
       return (this.analysisStatus.microreact === 'finished') ? 'showButton' : this.analysisStatus.microreact;
     },
     getNetwork() {
       return (this.analysisStatus.network === 'finished') ? 'showButton' : this.analysisStatus.network;
+    },
+    onInput(value: number) {
+      this.rank = value;
     },
   },
   computed: {
@@ -112,12 +142,13 @@ export default defineComponent({
           Sketch: (samples[sample].sketch) ? '\u2714' : 'processing',
           AMR: samples[sample].amr ? samples[sample].amr : 'processing',
           Cluster: this.submitStatus === 'submitted' ? this.getCluster(sample) : '',
+          Lineage: this.submitStatus === 'submitted' ? this.getLineage(sample, this.rank) : '',
           Microreact: this.submitStatus === 'submitted' ? this.getMicroreact() : '',
           Network: this.submitStatus === 'submitted' ? this.getNetwork() : '',
         });
       });
       const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
-      if (this.analysisStatus.assign === 'finished') {
+      if (this.analysisStatus.assignClusters === 'finished') {
         // adding a rowspan property to merge microreact/ network cells from same cluster
         const tableRowspan = addRowspan(tableSorted);
         return tableRowspan;

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -177,3 +177,17 @@ small {
     border-top: 0;
     border-bottom: 0;
 }
+
+.dropdown {
+    position: relative;
+    display: flex;
+}
+
+.dropdown-toggle {
+    flex-grow: 1;
+    padding: 0 !important;
+}
+
+.dropdown-menu {
+    background-color: white !important;
+}

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -17,7 +17,8 @@ export default new Vuex.Store<RootState>({
     projectHash: null,
     submitStatus: null,
     analysisStatus: {
-      assign: null,
+      assignClusters: null,
+      assignLineages: null,
       microreact: null,
       network: null,
     },

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -1,6 +1,6 @@
 import { RootState } from '@/store/state';
 import {
-  Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError,
+  Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError, Dict,
 } from '@/types';
 
 export default {
@@ -43,9 +43,19 @@ export default {
     state.statusInterval = interval;
   },
   setClusters(state: RootState, clusterInfo: ClusterInfo) {
-    Object.keys(clusterInfo).forEach((element) => {
-      state.results.perIsolate[clusterInfo[element].hash]
-        .cluster = clusterInfo[element].cluster;
+    Object.keys(clusterInfo).forEach((cluster) => {
+      clusterInfo[cluster].forEach((hash) => {
+        state.results.perIsolate[hash].cluster = cluster;
+      });
+    });
+  },
+  setLineages(state: RootState, lineageInfo: Dict<Dict<string>>) {
+    Object.keys(lineageInfo).forEach((hash) => {
+      state.results.perIsolate[hash].lineage = {
+        rank1: lineageInfo[hash].rank1,
+        rank2: lineageInfo[hash].rank2,
+        rank3: lineageInfo[hash].rank3,
+      };
     });
   },
   addMicroreactURL(state: RootState, URLinfo: Record<string, string>) {

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -10,6 +10,7 @@ export interface Isolate {
     amr?: AMR
     sketch?: string
     cluster?: number | string
+    lineage?: Dict<string>
 }
 
 export interface Versions {
@@ -37,7 +38,8 @@ export interface IsolateValue {
 }
 
 export enum AnalysisType {
-    ASSIGN = 'assign',
+    ASSIGNCLUSTERS = 'assignClusters',
+    ASSIGNLINEAGES = 'assignLineages',
     MICROREACT = 'microreact',
     NETWORK = 'network'
 }
@@ -46,7 +48,7 @@ export type AnalysisStatus = {
     [key in AnalysisType]: string | null
 }
 
-export type ClusterInfo = Dict<Dict<string>>
+export type ClusterInfo = Dict<string[]>
 
 export interface BeebopError {
     error: string,

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -64,6 +64,14 @@ test.describe('Logged in Tests', () => {
     // Expect clusters appearing in table
     await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7']);
     await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24']);
+    // Expect lineages to appear in table
+    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7', '37']);
+    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24', '12']);
+    // Changing rank updates lineages
+    await page.click('text=Lineage Rank 1');
+    await page.click('text=Rank 2');
+    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7', '6']);
+    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24', '2']);
     // Expect download buttons and button to generate microreact URL to appear
     await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText('Download zip file');
     await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText('Generate Microreact URL');

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -19,7 +19,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
     },
     submitStatus: null,
     analysisStatus: {
-      assign: null, microreact: null, network: null,
+      assignClusters: null, assignLineages: null, microreact: null, network: null,
     },
     statusInterval: undefined,
     projectHash: null,

--- a/app/client/tests/unit/components/ProgressBar.spec.ts
+++ b/app/client/tests/unit/components/ProgressBar.spec.ts
@@ -7,14 +7,15 @@ import { mockRootState } from '../../mocks';
 describe('Progress bar', () => {
   const analysisProgress = jest.fn().mockReturnValue({
     finished: 1,
-    progress: 0.3333333333333333,
-    total: 3,
+    progress: 0.25,
+    total: 4,
   });
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
       analysisStatus: {
-        assign: 'finished',
+        assignClusters: 'finished',
+        assignLineages: 'queued',
         microreact: 'queued',
         network: 'started',
       },
@@ -37,21 +38,22 @@ describe('Progress bar', () => {
   it('gets analysisProgress and displays status', () => {
     expect(analysisProgress).toHaveBeenCalledTimes(1);
     expect(wrapper.vm.animated).toBe(true);
-    expect(wrapper.find('.progress-bar').text()).toBe('33.33%');
+    expect(wrapper.find('.progress-bar').text()).toBe('25.00%');
   });
 });
 
 describe('Progress bar finished', () => {
   const analysisProgress = jest.fn().mockReturnValue({
-    finished: 3,
+    finished: 4,
     progress: 1,
-    total: 3,
+    total: 4,
   });
 
   const store = new Vuex.Store<RootState>({
     state: mockRootState({
       analysisStatus: {
-        assign: 'finished',
+        assignClusters: 'finished',
+        assignLineages: 'finished',
         microreact: 'finished',
         network: 'finished',
       },

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -15,7 +15,8 @@ describe('ResultsTable complete', () => {
       },
       submitStatus: 'submitted',
       analysisStatus: {
-        assign: 'finished',
+        assignClusters: 'finished',
+        assignLineages: 'finished',
         microreact: 'finished',
         network: 'finished',
       },
@@ -26,6 +27,11 @@ describe('ResultsTable complete', () => {
             filename: 'example1.fa',
             sketch: 'sketch',
             cluster: 7,
+            lineage: {
+              rank1: "12",
+              rank2: "3",
+              rank3: "2",
+            },
             amr: {
               filename: 'example1.fa',
               Penicillin: 0.892,
@@ -40,6 +46,11 @@ describe('ResultsTable complete', () => {
             filename: 'example2.fa',
             sketch: 'sketch',
             cluster: 3,
+            lineage: {
+              rank1: "7",
+              rank2: "2",
+              rank3: "2",
+            },
             amr: {
               filename: 'example2.fa',
               Penicillin: 0.892,
@@ -54,6 +65,11 @@ describe('ResultsTable complete', () => {
             filename: 'example3.fa',
             sketch: 'sketch',
             cluster: 7,
+            lineage: {
+              rank1: "15",
+              rank2: "4",
+              rank3: "2",
+            },
             amr: {
               filename: 'example3.fa',
               Penicillin: 0.892,
@@ -94,6 +110,7 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 3,
+        Lineage: '7',
         Microreact: 'showButton',
         Network: 'showButton',
         Rowspan: 1,
@@ -111,6 +128,7 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 7,
+        Lineage: '12',
         Microreact: 'showButton',
         Network: 'showButton',
         Rowspan: 2,
@@ -128,6 +146,7 @@ describe('ResultsTable complete', () => {
           Trim_sulfa: 0.974,
         },
         Cluster: 7,
+        Lineage: '15',
         Microreact: 'showButton',
         Network: 'showButton',
         Rowspan: 0,
@@ -150,24 +169,33 @@ describe('ResultsTable complete', () => {
   test('results are displayed in the table', () => {
     // 6 headers exist
     const headers = wrapper.findAll('th');
-    expect(headers.length).toBe(6);
+    expect(headers.length).toBe(7);
     // 3 rows exist
     const rows = wrapper.findAll('tr');
     expect(rows.length).toBe(3);
     // 16 cells exist (3x6 minus two merged cells)
     const cells = wrapper.findAll('td');
-    expect(cells.length).toBe(16);
+    expect(cells.length).toBe(19);
     // first cell in each row displays filenames
     expect(cells[0].text()).toBe('example2.fa');
-    expect(cells[6].text()).toBe('example1.fa');
-    expect(cells[12].text()).toBe('example3.fa');
+    expect(cells[7].text()).toBe('example1.fa');
+    expect(cells[14].text()).toBe('example3.fa');
     // microreact & network cells from same cluster are merged
-    expect(cells[10].attributes('rowspan')).toBe('2');
-    expect(cells[11].attributes('rowspan')).toBe('2');
+    expect(cells[12].attributes('rowspan')).toBe('2');
+    expect(cells[13].attributes('rowspan')).toBe('2');
     // AMR cells have tooltip
     const amrCells = wrapper.findAll('span');
     expect(amrCells.length).toBe(3);
     expect(amrCells[0].attributes('data-bs-original-title')).toBe(mockTooltipText);
+  });
+
+  test('selecting another rank from lineage dropdown menu changes lineages', async () => {
+    const cells = wrapper.findAll('td');
+    expect(cells[4].text()).toBe('7');
+    expect(wrapper.findAll('.dropdown-item')).toHaveLength(3);
+    await wrapper.find('#two').trigger('click');
+    expect(wrapper.vm.rank).toBe(2);
+    expect(cells[4].text()).toBe('2');
   });
 });
 
@@ -181,7 +209,8 @@ describe('ResultsTable incomplete', () => {
       },
       submitStatus: 'submitted',
       analysisStatus: {
-        assign: 'started',
+        assignClusters: 'started',
+        assignLineages: 'waiting',
         microreact: 'waiting',
         network: 'waiting',
       },
@@ -241,14 +270,15 @@ describe('ResultsTable incomplete', () => {
   test('results are displayed in the table', () => {
     const cells = wrapper.findAll('td');
     // cells not yet merged
-    expect(cells.length).toBe(18);
+    expect(cells.length).toBe(21);
     // filenames not yet sorted by cluster
     expect(cells[0].text()).toBe('example1.fa');
-    expect(cells[6].text()).toBe('example2.fa');
-    expect(cells[12].text()).toBe('example3.fa');
-    // cluster, microreact and network cells show analysis status
+    expect(cells[7].text()).toBe('example2.fa');
+    expect(cells[14].text()).toBe('example3.fa');
+    // cluster, lineage, microreact and network cells show analysis status
     expect(cells[3].text()).toBe('started');
     expect(cells[4].text()).toBe('waiting');
     expect(cells[5].text()).toBe('waiting');
+    expect(cells[6].text()).toBe('waiting');
   });
 });

--- a/app/client/tests/unit/store/getters.spec.ts
+++ b/app/client/tests/unit/store/getters.spec.ts
@@ -7,15 +7,16 @@ describe('getters', () => {
       projectHash: 'randomHash',
       submitStatus: 'submitted',
       analysisStatus: {
-        assign: 'finished',
+        assignClusters: 'finished',
+        assignLineages: 'finished',
         microreact: 'started',
         network: 'queued',
       },
     });
     expect(getters.analysisProgress(state, 'analysisProgress', state, 'analysisProgress')).toStrictEqual({
-      finished: 1,
-      progress: 0.3333333333333333,
-      total: 3,
+      finished: 2,
+      progress: 0.5,
+      total: 4,
     });
   });
   it('gets unique clusters', () => {

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -92,7 +92,8 @@ describe('mutations', () => {
   it('sets analysisStatus', () => {
     const state = mockRootState();
     const statusUpdate = {
-      assign: 'finished',
+      assignClusters: 'finished',
+      assignLineages: 'finished',
       microreact: 'started',
       network: 'queued',
     };
@@ -125,8 +126,37 @@ describe('mutations', () => {
         perCluster: {},
       },
     });
-    mutations.setClusters(state, { 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } });
+    mutations.setClusters(state, { 12: ['someFileHash'], 1: ['someFileHash2'] });
     expect(state.results.perIsolate.someFileHash.cluster).toBe('12');
+  });
+  it('sets lineages', () => {
+    const state = mockRootState({
+      results: {
+        perIsolate: {
+          someFileHash: {
+            hash: 'someFileHash',
+          },
+          someFileHash2: {
+            hash: 'someFileHash2',
+          },
+        },
+        perCluster: {},
+      },
+    });
+    mutations.setLineages(state, { 'someFileHash': {
+      rank1: "12",
+      rank2: "3",
+      rank3: "2",
+    }, 'someFileHash2': {
+      rank1: "15",
+      rank2: "4",
+      rank3: "2",
+    }});
+    expect(state.results.perIsolate.someFileHash.lineage).toStrictEqual({
+      rank1: "12",
+      rank2: "3",
+      rank3: "2",
+    });
   });
   it('sets MicroreactURL', () => {
     const state = mockRootState();

--- a/app/client/tests/unit/views/HomeView.spec.ts
+++ b/app/client/tests/unit/views/HomeView.spec.ts
@@ -96,7 +96,7 @@ describe('Home', () => {
         },
         submitStatus: null,
         analysisStatus: {
-          assign: null, microreact: null, network: null,
+          assignClusters: null, assignLineages: null, microreact: null, network: null,
         },
       }),
       actions: {
@@ -116,8 +116,8 @@ describe('Home', () => {
   it('shows status bar when data was submitted to backend', () => {
     const analysisProgress = jest.fn().mockReturnValue({
       finished: 1,
-      progress: 0.3333333333333333,
-      total: 3,
+      progress: 0.25,
+      total: 4,
     });
     const store = new Vuex.Store<RootState>({
       state: mockRootState({
@@ -135,7 +135,7 @@ describe('Home', () => {
         },
         submitStatus: 'submitted',
         analysisStatus: {
-          assign: 'finished', microreact: 'started', network: 'queued',
+          assignClusters: 'finished', assignLineages: 'queued', microreact: 'started', network: 'queued',
         },
       }),
       actions: {
@@ -153,6 +153,6 @@ describe('Home', () => {
     const statusBar = wrapper.findAll('.progress');
     expect(analysisProgress).toHaveBeenCalled();
     expect(statusBar.length).toBe(1);
-    expect(statusBar[0].text()).toBe('33.33%'); // Nan
+    expect(statusBar[0].text()).toBe('25.00%'); // Nan
   });
 });

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -23,9 +23,13 @@ export const router = ((app, config) => {
         authCheck,
         api.getStatus);
 
-    app.post('/assignResult',
+    app.post('/assignClustersResult',
         authCheck,
-        api.getAssignResult);
+        api.getAssignClustersResult);
+
+        app.post('/assignLineagesResult',
+        authCheck,
+        api.getAssignLineagesResult);
 
     app.get('/login/google',
         passport.authenticate('google', { scope: ['profile'] }));
@@ -170,8 +174,22 @@ export const apiEndpoints = (config => ({
             });
     },
 
-    async getAssignResult(request, response) {
-        await axios.post(`${config.api_url}/results/assign`,
+    async getAssignClustersResult(request, response) {
+        await axios.post(`${config.api_url}/results/assignClusters`,
+            request.body,
+            {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(res => response.send(res.data))
+            .catch(function (error) {
+                sendError(response, error);
+            });
+    },
+
+    async getAssignLineagesResult(request, response) {
+        await axios.post(`${config.api_url}/results/assignLineages`,
             request.body,
             {
                 headers: {

--- a/scripts/run_test
+++ b/scripts/run_test
@@ -4,7 +4,7 @@ NETWORK=beebop_nw
 VOLUME=beebop-storage
 NAME_REDIS=beebop-redis
 NAME_API=beebop-py-api
-API_BRANCH=bacpop-61
+API_BRANCH=bacpop-71
 NAME_WORKER=beebop-py-worker
 PORT=5000
 


### PR DESCRIPTION
Lineage results (3 ranks per isolate) are now be displayed in results table. With a dropdown column header the user can switch between ranks.

Cluster results format changed to accomodate lineage assignment, therefore this mutation needed to be adjusted.
