### PR TITLE
bacpop-77 Create project with name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The backend can be tested with
 ```
 npm run test
 ```
-insinde `app/server`.
+from `app/server`.
 
 ### End-to-end tests
 To run end-to-end test, the app must be started with `./scripts/run_test`. In a new terminal, these test can be launched with

--- a/app/client/src/components/NavbarDropdown.vue
+++ b/app/client/src/components/NavbarDropdown.vue
@@ -6,7 +6,7 @@
         data-bs-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false">
-          <span class="mr-2">{{ loggedInText }}</span>
+          <span id="logged-in-user" class="mr-2">{{ loggedInText }}</span>
           <i class="bi bi-three-dots-vertical huge menu icon"></i>
         </div>
         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">

--- a/app/client/src/components/NavbarDropdown.vue
+++ b/app/client/src/components/NavbarDropdown.vue
@@ -6,7 +6,8 @@
         data-bs-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false">
-        <i class="bi bi-three-dots-vertical huge menu"></i>
+          <span class="mr-2">{{ loggedInText }}</span>
+          <i class="bi bi-three-dots-vertical huge menu icon"></i>
         </div>
         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
           <router-link class="dropdown-item menu-item"  to="/">
@@ -41,6 +42,9 @@ export default {
       return `${config.serverUrl()}/logout`;
     },
     ...mapState(['user']),
+    loggedInText() {
+      return this.user ? `Logged in as ${this.user.name}` : '';
+    },
   },
 };
 </script>

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -1,37 +1,45 @@
 <template>
-  <div class="select-action">
-    <i class="bi bi-house-fill left house"></i>
-    <p class="left">Welcome back, {{user.name}}!</p>
-    <button
-    class="btn btn-block btn-standard btn-selection"
-    @click="runAnalysis">Run new analysis</button>
-    <!-- These buttons are just dummies so far -->
-    <button class="btn btn-block btn-standard btn-selection disabled">See previous analyses</button>
-    <!--<button class="btn btn-block btn-standard btn-selection disabled">Manage my data</button>-->
+  <div class="mt-3 container left">
+    <div class="row">
+      <div class="col-6">
+        <input id="create-project-name"
+               placeholder="Project name"
+               type="text"
+               v-model="projectName"
+               aria-label="Project name"
+               class="form-control input-text">
+      </div>
+      <div class="col-6">
+        <button
+        class="btn btn-standard"
+        @click="runAnalysis">Create new project</button>
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang='ts'>
 import { defineComponent } from 'vue';
-import { mapState, mapActions } from 'vuex';
+import { mapActions, mapMutations } from 'vuex';
 
 export default defineComponent({
   name: 'SelectAction',
+  data() {
+    return {
+      projectName: '',
+    };
+  },
   mounted() {
     this.getUser();
   },
   methods: {
     ...mapActions(['getUser']),
+    ...mapMutations(['setProjectName']),
     runAnalysis() {
+      // TODO: disable button when name is empty
+      this.setProjectName(this.projectName);
       this.$router.push('/project');
     },
   },
-  computed: {
-    ...mapState(['user']),
-  },
 });
 </script>
-
-<style>
-@import 'bootstrap-icons/font/bootstrap-icons.css';
-</style>

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -12,6 +12,7 @@
       </div>
       <div class="col-6">
         <button
+        id="create-project-btn"
         class="btn btn-standard"
         :disabled="!projectName"
         @click="runAnalysis">Create new project</button>

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -7,7 +7,8 @@
                type="text"
                v-model="projectName"
                aria-label="Project name"
-               class="form-control input-text">
+               class="form-control input-text"
+               @keyup.enter="runAnalysis">
       </div>
       <div class="col-6">
         <button
@@ -37,8 +38,10 @@ export default defineComponent({
     ...mapActions(['getUser']),
     ...mapMutations(['setProjectName']),
     runAnalysis() {
-      this.setProjectName(this.projectName);
-      this.$router.push('/project');
+      if (this.projectName) {
+        this.setProjectName(this.projectName);
+        this.$router.push('/project');
+      }
     },
   },
 });

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -12,6 +12,7 @@
       <div class="col-6">
         <button
         class="btn btn-standard"
+        :disabled="!projectName"
         @click="runAnalysis">Create new project</button>
       </div>
     </div>
@@ -36,7 +37,6 @@ export default defineComponent({
     ...mapActions(['getUser']),
     ...mapMutations(['setProjectName']),
     runAnalysis() {
-      // TODO: disable button when name is empty
       this.setProjectName(this.projectName);
       this.$router.push('/project');
     },

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -298,3 +298,7 @@ th {
     font-size: 2rem;
     color: black;
 }
+
+.icon {
+    vertical-align: middle;
+}

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -14,15 +14,6 @@
     width: 200px;
 }
 
-.select-action {
-    width: 80%;
-    margin: auto;
-    padding: 50px 0px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
 .left {
     text-align: start;
 }
@@ -66,9 +57,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-}
-.btn-selection {
-    width: 300px;
 }
 
 .btn-standard {
@@ -123,6 +111,10 @@
     margin: 3px;
     line-height: 25px;
     font-size: 1em;
+}
+
+.input-text {
+    margin: 8px;
 }
 
 .progress {

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -73,6 +73,7 @@ export default {
       .ignoreSuccess()
       .post<AnalysisStatus>(`${serverUrl}/poppunk`, {
         projectHash: phash,
+        projectName: state.projectName,
         sketches: jsonSketches,
         names: filenameMapping,
       });

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -15,6 +15,7 @@ export default new Vuex.Store<RootState>({
       perCluster: {},
     },
     projectHash: null,
+    projectName: null,
     submitStatus: null,
     analysisStatus: {
       assign: null,

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -7,6 +7,9 @@ export default {
   addError(state: RootState, payload: BeebopError) {
     state.errors.push(payload);
   },
+  setProjectName(state: RootState, projectName: string) {
+    state.projectName = projectName;
+  },
   setVersions(state: RootState, versioninfo: Versions) {
     state.versions = versioninfo;
   },

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -15,5 +15,6 @@ export interface RootState {
   submitStatus: string | null
   analysisStatus: AnalysisStatus
   projectHash: string | null
+  projectName: string | null
   statusInterval: number | undefined
 }

--- a/app/client/src/views/ProjectView.vue
+++ b/app/client/src/views/ProjectView.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <h2>Create a new project</h2>
     <div class="project">
       <div class="file-input">
         <DropZone v-if="user && !submitStatus" class="dropzone-component"/>
       </div>
       <div class="overview">
+        <h2 class="left">Project: {{projectName}}</h2>
         <StartButton v-if="user" />
         <ProgressBar v-if="submitStatus" class="progress-bar-component" />
 
@@ -77,7 +77,12 @@ export default defineComponent({
     };
   },
   mounted() {
-    this.getUser();
+    // redirect to home page if no project name
+    if (!this.projectName) {
+      this.$router.push('/');
+    } else {
+      this.getUser();
+    }
   },
   methods: {
     ...mapActions(['getUser']),
@@ -86,7 +91,7 @@ export default defineComponent({
     },
   },
   computed: {
-    ...mapState(['user', 'submitStatus', 'analysisStatus']),
+    ...mapState(['user', 'submitStatus', 'analysisStatus', 'projectName']),
     ...mapGetters(['uniqueClusters']),
   },
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -23,12 +23,20 @@ test.describe('Logged in Tests', () => {
   });
 
   test('should display dropzone in Project view', async ({ page }) => {
-    await page.click('text=Run new analysis');
+    await page.fill('input#create-project-name', 'test project');
+    await page.click('button#create-project-btn');
     await expect(page.locator('.dropzone')).toBeVisible();
+    await expect(page.locator('h2')).toContainText('Project: test project');
+  });
+
+  test('should redirect from project page to home page if name has not been provided', async ({page}) => {
+    await page.goto(`${config.clientUrl()}/project`);
+    await expect(await page.locator('button#create-project-btn')).toBeVisible();
   });
 
   test('should update file list when files are dropped, process them in WebWorker and submit on click to backend', async ({ page }) => {
-    await page.click('text=Run new analysis');
+    await page.fill('input#create-project-name', 'test project');
+    await page.click('button#create-project-btn');
     // Read files into a buffer
     const buffer = readFileSync('./tests/files/6930_8_13.fa', { encoding: 'utf8', flag: 'r' });
     const buffer2 = readFileSync('./tests/files/6930_8_11.fa', { encoding: 'utf8', flag: 'r' });

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -23,6 +23,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
     },
     statusInterval: undefined,
     projectHash: null,
+    projectName: null,
     ...state,
   };
 }

--- a/app/client/tests/unit/components/NavbarDropdown.spec.ts
+++ b/app/client/tests/unit/components/NavbarDropdown.spec.ts
@@ -36,6 +36,10 @@ describe('NavbarDropdown logged in', () => {
     expect(wrapper.find('a#logout-link').text()).toBe('Logout');
     expect(wrapper.findAll('.dropdown-divider').length).toBe(1);
   });
+
+  test('shows logged in user text', () => {
+    expect(wrapper.find('#logged-in-user').text()).toBe('Logged in as Jane');
+  });
 });
 
 describe('NavbarDropdown logged out', () => {
@@ -59,5 +63,9 @@ describe('NavbarDropdown logged out', () => {
     expect(links[0].text()).toBe('Home');
     expect(links[1].text()).toBe('About');
     expect(wrapper.findAll('.dropdown-divider').length).toBe(0);
+  });
+
+  test('shows no logged in user text', () => {
+    expect(wrapper.find('#logged-in-user').text()).toBe('');
   });
 });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -83,6 +83,7 @@ describe('Actions', () => {
   it('runPoppunk makes axios call', async () => {
     const commit = jest.fn();
     const state = mockRootState({
+      projectName: 'test project',
       results: {
         perIsolate: {
           someFileHash: {
@@ -103,6 +104,18 @@ describe('Actions', () => {
     }));
     await actions.runPoppunk({ commit, state } as any);
     expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/poppunk`);
+    expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({
+      projectHash: expectedHash,
+      projectName: 'test project',
+      sketches: {
+        someFileHash: { 14: '12345' },
+        someFileHash2: { 14: '12345' },
+      },
+      names: {
+        someFileHash: 'someFilename',
+        someFileHash2: 'someFilename2',
+      },
+    });
     expect(commit.mock.calls[0]).toEqual([
       'setProjectHash',
       expectedHash]);

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -151,4 +151,9 @@ describe('mutations', () => {
     mutations.addGraphml(state, mockGraphInfo);
     expect(state.results.perCluster[mockGraphInfo.cluster]).toStrictEqual({ cluster: '7', graph: '<graph></graph>' });
   });
+  it('sets project name', () => {
+    const state = mockRootState();
+    mutations.setProjectName(state, 'test name');
+    expect(state.projectName).toBe('test name');
+  });
 });

--- a/app/client/tests/unit/views/HomeView.spec.ts
+++ b/app/client/tests/unit/views/HomeView.spec.ts
@@ -49,7 +49,7 @@ describe('Home', () => {
     expect(socialButtons[1].text()).toBe('Login with Github');
   });
 
-  it('shows options to select when logged in', () => {
+  it('shows create project controls when logged in', () => {
     const store = new Vuex.Store<RootState>({
       state: mockRootState({
         user: {
@@ -71,9 +71,7 @@ describe('Home', () => {
         plugins: [store],
       },
     });
-    const buttons = wrapper.findAll('.btn-standard');
-    expect(buttons.length).toBe(2);
-    expect(buttons[0].text()).toBe('Run new analysis');
-    expect(buttons[1].text()).toBe('See previous analyses');
+    expect(wrapper.find('input#create-project-name').exists()).toBe(true);
+    expect(wrapper.find('button#create-project-btn').exists()).toBe(true);
   });
 });

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -58,6 +58,7 @@ describe('Project', () => {
 
     const store = new Vuex.Store<RootState>({
       state: mockRootState({
+        projectName: "testProject",
         user: {
           name: 'Jane',
           id: '543653d45',
@@ -160,7 +161,7 @@ describe('Project', () => {
         getUser,
       },
     });
-    const wrapper = mount(ProjectView, {
+    mount(ProjectView, {
       global: {
         plugins: [store],
         mocks: {

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -6,14 +6,18 @@ import { mockRootState } from '../../mocks';
 
 describe('Project', () => {
   const getUser = jest.fn();
+  const mockRouter = {
+    push: jest.fn(),
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it('displays dropzone, startbutton and empty table message, gets user information on mount', () => {
+  it('displays as expected, gets user information on mount', () => {
     const store = new Vuex.Store<RootState>({
       state: mockRootState({
+        projectName: 'test project',
         user: {
           name: 'Jane',
           id: '543653d45',
@@ -27,15 +31,20 @@ describe('Project', () => {
     const wrapper = mount(ProjectView, {
       global: {
         plugins: [store],
+        mocks: {
+          $router: mockRouter,
+        },
       },
     });
 
+    expect(wrapper.find('h2').text()).toBe('Project: test project');
     expect(wrapper.findAll('.dropzone-component').length).toBe(1);
     const buttons = wrapper.findAll('.btn-standard');
     expect(buttons.length).toBe(1);
     expect(buttons[0].text()).toBe('Start Analysis');
     expect(wrapper.find('div#no-results').text()).toBe('No data uploaded yet');
     expect(getUser).toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
   });
 
   it('after submission  dropzone disappears, now has progress bar and table and network tabs + panes ', () => {
@@ -135,5 +144,33 @@ describe('Project', () => {
     expect(wrapper.vm.selectedTab).toBe('table');
     tabs[1].trigger('click');
     expect(wrapper.vm.selectedTab).toBe('network');
+  });
+
+  it('redirects to root if no project name', () => {
+    const store = new Vuex.Store<RootState>({
+      state: mockRootState({
+        projectName: null,
+        user: {
+          name: 'Jane',
+          id: '543653d45',
+          provider: 'google',
+        },
+      }),
+      actions: {
+        getUser,
+      },
+    });
+    const wrapper = mount(ProjectView, {
+      global: {
+        plugins: [store],
+        mocks: {
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
+    expect(mockRouter.push.mock.calls[0][0]).toBe('/');
   });
 });

--- a/app/server/src/requestTypes.ts
+++ b/app/server/src/requestTypes.ts
@@ -1,6 +1,9 @@
 export interface PoppunkRequest {
     names: Record<string, unknown>,
     projectHash: string,
-    projectName: string,
     sketches: Record<string, never>
+}
+
+export interface BeebopRunRequest extends PoppunkRequest {
+    projectName: string,
 }

--- a/app/server/src/requestTypes.ts
+++ b/app/server/src/requestTypes.ts
@@ -1,5 +1,6 @@
 export interface PoppunkRequest {
     names: Record<string, unknown>,
     projectHash: string,
+    projectName: string,
     sketches: Record<string, never>
 }

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -150,9 +150,10 @@ export const apiEndpoints = (config => ({
 
     async runPoppunk(request, response, next) {
         await asyncHandler(next, async () => {
-            const projectHash = (request.body as PoppunkRequest).projectHash;
+            const poppunkRequest = request.body as PoppunkRequest;
+            const {projectHash, projectName} = poppunkRequest;
             const {redis} = request.app.locals;
-            await userStore(redis).saveProjectHash(request, projectHash);
+            await userStore(redis).saveNewProject(request, projectHash, projectName);
 
             await axios.post(`${config.api_url}/poppunk`,
                 request.body,

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -152,6 +152,7 @@ export const apiEndpoints = (config => ({
         await asyncHandler(next, async () => {
             const poppunkRequest = request.body as PoppunkRequest;
             const {projectHash, projectName} = poppunkRequest;
+            console.log("Got project name " + projectName);
             const {redis} = request.app.locals;
             await userStore(redis).saveNewProject(request, projectHash, projectName);
 

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import passport from 'passport';
-import {PoppunkRequest} from "../requestTypes";
+import {BeebopRunRequest, PoppunkRequest} from "../requestTypes";
 import {userStore} from "../db/userStore";
 import asyncHandler from "../errors/asyncHandler";
 
@@ -150,14 +150,14 @@ export const apiEndpoints = (config => ({
 
     async runPoppunk(request, response, next) {
         await asyncHandler(next, async () => {
-            const poppunkRequest = request.body as PoppunkRequest;
-            const {projectHash, projectName} = poppunkRequest;
-            console.log("Got project name " + projectName);
+            const poppunkRequest = request.body as BeebopRunRequest;
+            const {projectHash, projectName, names, sketches} = poppunkRequest;
             const {redis} = request.app.locals;
             await userStore(redis).saveNewProject(request, projectHash, projectName);
 
+            const apiRequest = {names, projectHash, sketches} as PoppunkRequest;
             await axios.post(`${config.api_url}/poppunk`,
-                request.body,
+                apiRequest,
                 {
                     headers: {
                         'Content-Type': 'application/json'

--- a/app/server/tests/integration/persistence.test.ts
+++ b/app/server/tests/integration/persistence.test.ts
@@ -8,13 +8,16 @@ describe("User persistence", () => {
         connectionCookie = response.headers["set-cookie"][0];
     });
 
-    it("adds user - project hash mapping to redis", async () => {
+    it("adds user - project hash - project name mappings to redis", async () => {
         const payload = {
-            projectHash: "9876"
+            projectHash: "9876",
+            projectName: "test name"
         };
         await post("poppunk", payload, connectionCookie);
         const mapping = await getRedisValues("beebop:user:hash");
         expect(Object.keys(mapping).length).toBe(1);
         expect(mapping["mock:1234"]).toBe("9876");
+        const nameMapping = await getRedisValues("beebop:userproject:name");
+        expect(nameMapping["mock:1234:9876"]).toBe("test name");
     });
 });

--- a/app/server/tests/unit/db/userStore.test.ts
+++ b/app/server/tests/unit/db/userStore.test.ts
@@ -18,7 +18,7 @@ describe("UserStore", () => {
         } as any;
 
         const sut = new UserStore(mockRedis);
-        await sut.saveProjectHash(mockRequest, "testProjectHash");
+        await sut.saveNewProject(mockRequest, "testProjectHash");
         expect(mockRedis.hset).toHaveBeenCalledTimes(1);
         const params = mockRedis.hset.mock.calls[0];
         expect(params[0]).toBe("beebop:user:hash");

--- a/app/server/tests/unit/db/userStore.test.ts
+++ b/app/server/tests/unit/db/userStore.test.ts
@@ -9,7 +9,7 @@ describe("UserStore", () => {
         jest.clearAllMocks();
     });
 
-    it("saves project hash", async () => {
+    it("saves new project data", async () => {
         const mockRequest = {
             user: {
                 provider: "testProvider",
@@ -18,12 +18,16 @@ describe("UserStore", () => {
         } as any;
 
         const sut = new UserStore(mockRedis);
-        await sut.saveNewProject(mockRequest, "testProjectHash");
-        expect(mockRedis.hset).toHaveBeenCalledTimes(1);
-        const params = mockRedis.hset.mock.calls[0];
-        expect(params[0]).toBe("beebop:user:hash");
-        expect(params[1]).toBe("testProvider:testId");
-        expect(params[2]).toBe("testProjectHash");
+        await sut.saveNewProject(mockRequest, "testProjectHash", "test project name");
+        expect(mockRedis.hset).toHaveBeenCalledTimes(2);
+        const setUserHashParams = mockRedis.hset.mock.calls[0];
+        expect(setUserHashParams[0]).toBe("beebop:user:hash");
+        expect(setUserHashParams[1]).toBe("testProvider:testId");
+        expect(setUserHashParams[2]).toBe("testProjectHash")
+        const setProjectNameParams = mockRedis.hset.mock.calls[1];
+        expect(setProjectNameParams[0]).toBe("beebop:userproject:name");
+        expect(setProjectNameParams[1]).toBe("testProvider:testId:testProjectHash");
+        expect(setProjectNameParams[2]).toBe("test project name");
     });
 
 });


### PR DESCRIPTION
This PR requires users to enter a name when creating a new project, and persists that name to redis when the analysis is started. Some related UI changes are also included, Future branches will provide management and reloading of a user's previous projects. 

Key changes:
- the client includes the project name along with the project hash in the request to run poppunk
- however this means that the request format to the beebop client now differs from the poppunk request format (that request fails when projectName is included) so there are now two server request types, and the server strips out projectName when forwarding the request to poppunk
- the projectName is saved to redis, associated with both the projectHash and the user (since different users could create projects with the same hash if they used multiple files, but may name them differently). 
- front end UI changes to start converting the Home page into a Projects page as shown in [mockup](https://docs.google.com/presentation/d/1htgjPhrGWn8R7aYiJ3A4DEEUUOv6A7rlXB_NhEJrf7s/edit?usp=sharing). Removed unimplemented buttons and home icon, and added input and button for creating project with a required name. 
- Added redirect from the analysis page back to the home page if project has no name - require user to provide a name before proceeding. 
- Removed the welcome user message in the home page, but added a 'Logged in as' label to the header so that info is always visible. 
- Project name is shown as header in the analysis page. NB there is a separate epic for restyling the analysis page more fully