### PR TITLE
bacpop-95 eslint rule changes

### DIFF
--- a/app/client/.editorconfig
+++ b/app/client/.editorconfig
@@ -1,6 +1,6 @@
 [*.{js,jsx,ts,tsx,vue}]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/app/client/.editorconfig
+++ b/app/client/.editorconfig
@@ -4,4 +4,4 @@ indent_size = 4
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 100
+max_line_length = 120

--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -1,0 +1,49 @@
+module.exports = {
+    root: true,
+    env: {
+        node: true
+    },
+    extends: [
+        "plugin:vue/vue3-essential",
+        "@vue/airbnb",
+        "@vue/typescript/recommended"
+    ],
+    parserOptions: {
+        ecmaVersion: 2020
+    },
+    rules: {
+        "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
+        "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+        "comma-dangle": ["error", "never"],
+        indent: ["error", 4],
+        quotes: ["error", "double", { avoidEscape: true }],
+        "max-len": [2, 120, 4],
+        "arrow-body-style": "off",
+        "import/prefer-default-export": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
+        "no-underscore-dangle": "off",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error"]
+    },
+    overrides: [{
+        files: [
+            "**/tests/**/*.{j,t}s"
+        ],
+        env: {
+            jest: true
+        },
+        rules: {
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/explicit-module-boundary-types": "off",
+            "@typescript-eslint/no-unused-vars": "off",
+            "@typescript-eslint/no-empty-function": "off",
+            "max-classes-per-file": "off",
+            "no-useless-constructor": "off"
+        }
+    }],
+    globals: {
+        NodeJS: true
+    }
+};

--- a/app/client/babel.config.js
+++ b/app/client/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset',
-  ],
+    presets: [
+        "@vue/cli-plugin-babel/preset"
+    ]
 };

--- a/app/client/jest.config.js
+++ b/app/client/jest.config.js
@@ -1,14 +1,14 @@
 module.exports = {
-  preset: '@vue/cli-plugin-unit-jest/presets/typescript-and-babel',
-  transformIgnorePatterns: [
-    '/node_modules/(?!vuex-composition-helpers).+\\.js$',
-  ],
-  collectCoverage: true,
-  collectCoverageFrom: [
-    'src/**/*.{ts,vue}',
-    '!src/main.ts',
-  ],
-  moduleNameMapper: {
-    '^@settings(.*)$': '<rootDir>/src/settings/development/$1',
-  },
+    preset: "@vue/cli-plugin-unit-jest/presets/typescript-and-babel",
+    transformIgnorePatterns: [
+        "/node_modules/(?!vuex-composition-helpers).+\\.js$"
+    ],
+    collectCoverage: true,
+    collectCoverageFrom: [
+        "src/**/*.{ts,vue}",
+        "!src/main.ts"
+    ],
+    moduleNameMapper: {
+        "^@settings(.*)$": "<rootDir>/src/settings/development/$1"
+    }
 };

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -60,43 +60,6 @@
     "typescript": "~4.5.5",
     "vm": "^0.1.0"
   },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true
-    },
-    "extends": [
-      "plugin:vue/vue3-essential",
-      "@vue/airbnb",
-      "@vue/typescript/recommended"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2020
-    },
-    "rules": {
-      "no-shadow": "off",
-      "@typescript-eslint/no-shadow": [
-        "error"
-      ]
-    },
-    "overrides": [
-      {
-        "files": [
-          "**/__tests__/*.{j,t}s?(x)",
-          "**/tests/unit/**/*.spec.{j,t}s?(x)",
-          "**/tests/**/*.{j,t}s"
-        ],
-        "env": {
-          "jest": true
-        },
-        "rules": {
-          "@typescript-eslint/no-explicit-any": "off",
-          "@typescript-eslint/no-empty-function": "off",
-          "no-underscore-dangle": "off"
-        }
-      }
-    ]
-  },
   "browserslist": [
     "> 1%",
     "last 2 versions",

--- a/app/client/src/App.vue
+++ b/app/client/src/App.vue
@@ -9,20 +9,20 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapActions } from 'vuex';
-import NavbarDropdown from '@/components/NavbarDropdown.vue';
+import { defineComponent } from "vue";
+import { mapActions } from "vuex";
+import NavbarDropdown from "@/components/NavbarDropdown.vue";
 
 export default defineComponent({
-  components: {
-    NavbarDropdown,
-  },
-  mounted() {
-    this.getUser();
-  },
-  methods: {
-    ...mapActions(['getUser']),
-  },
+    components: {
+        NavbarDropdown
+    },
+    mounted() {
+        this.getUser();
+    },
+    methods: {
+        ...mapActions(["getUser"])
+    }
 });
 </script>
 

--- a/app/client/src/apiService.ts
+++ b/app/client/src/apiService.ts
@@ -1,21 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-console */
-import axios, { AxiosError, AxiosResponse } from 'axios';
-import { Commit, ActionContext } from 'vuex';
-import { ResponseSuccess, ResponseFailure, BeebopError } from './types';
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { Commit, ActionContext } from "vuex";
+import { ResponseSuccess, ResponseFailure, BeebopError } from "./types";
 
 export interface ResponseWithType<T> extends ResponseSuccess {
     data: T
 }
 
 export function isAPIError(object: any): object is BeebopError {
-  return object && typeof object.error === 'string'
-        && (object.detail === undefined || typeof object.detail === 'string');
+    return object && typeof object.error === "string"
+        && (object.detail === undefined || typeof object.detail === "string");
 }
 
 export function isAPIResponseFailure(object: any): object is ResponseFailure {
-  return object && object.status === 'failure'
+    return object && object.status === "failure"
         && (Array.isArray(object.errors))
         && object.errors.every((e: any) => isAPIError(e));
 }
@@ -37,7 +37,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private readonly _commit: Commit;
 
     constructor(context: ActionContext<any, any>) {
-      this._commit = context.commit;
+        this._commit = context.commit;
     }
 
     private _ignoreErrors = false;
@@ -45,18 +45,18 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private _ignoreSuccess = false;
 
     static getFirstErrorFromFailure = (failure: ResponseFailure) => {
-      if (failure.errors.length === 0) {
-        return APIService
-          .createError('API response failed but did not contain any error information. Please contact support.');
-      }
-      return failure.errors[0];
+        if (failure.errors.length === 0) {
+            return APIService
+                .createError("API response failed but did not contain any error information. Please contact support.");
+        }
+        return failure.errors[0];
     };
 
     static createError(detail: string): BeebopError {
-      return {
-        error: 'MALFORMED_RESPONSE',
-        detail,
-      };
+        return {
+            error: "MALFORMED_RESPONSE",
+            detail
+        };
     }
 
     private _onError: OnError | null = null;
@@ -64,82 +64,82 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     private _onSuccess: OnSuccess | null = null;
 
     withError = (type: E) => {
-      this._onError = (failure: ResponseFailure) => {
-        if (APIService.getFirstErrorFromFailure(failure).error === 'Wrong Token') {
-          this._commit('setToken', null);
-        }
-        this._commit(type, APIService.getFirstErrorFromFailure(failure));
-      };
-      return this;
+        this._onError = (failure: ResponseFailure) => {
+            if (APIService.getFirstErrorFromFailure(failure).error === "Wrong Token") {
+                this._commit("setToken", null);
+            }
+            this._commit(type, APIService.getFirstErrorFromFailure(failure));
+        };
+        return this;
     };
 
     ignoreErrors = () => {
-      this._ignoreErrors = true;
-      return this;
+        this._ignoreErrors = true;
+        return this;
     };
 
     ignoreSuccess = () => {
-      this._ignoreSuccess = true;
-      return this;
+        this._ignoreSuccess = true;
+        return this;
     };
 
     withSuccess = (type: S) => {
-      this._onSuccess = (data: any) => {
-        this._commit(type, data);
-      };
-      return this;
+        this._onSuccess = (data: any) => {
+            this._commit(type, data);
+        };
+        return this;
     };
 
     private _handleAxiosResponse(promise: Promise<AxiosResponse>) {
-      return promise.then((axiosResponse: AxiosResponse) => {
-        const success = axiosResponse && axiosResponse.data;
-        const { data } = success;
-        if (this._onSuccess) {
-          this._onSuccess(data);
-        }
-        return axiosResponse.data;
-      }).catch((e: AxiosError) => this._handleError(e));
+        return promise.then((axiosResponse: AxiosResponse) => {
+            const success = axiosResponse && axiosResponse.data;
+            const { data } = success;
+            if (this._onSuccess) {
+                this._onSuccess(data);
+            }
+            return axiosResponse.data;
+        }).catch((e: AxiosError) => this._handleError(e));
     }
 
     private _handleError = (e: AxiosError) => {
-      console.log(e.response?.data || e);
-      if (this._ignoreErrors) {
-        return;
-      }
+        console.log(e.response?.data || e);
+        if (this._ignoreErrors) {
+            return;
+        }
 
-      const failure = e.response && e.response.data;
+        const failure = e.response && e.response.data;
 
-      if (!isAPIResponseFailure(failure)) {
-        this._commitError(APIService.createError('Could not parse API response. Please contact support.'));
-      } else if (this._onError) {
-        this._onError(failure);
-      } else {
-        this._commitError(APIService.getFirstErrorFromFailure(failure));
-      }
+        if (!isAPIResponseFailure(failure)) {
+            this._commitError(APIService.createError("Could not parse API response. Please contact support."));
+        } else if (this._onError) {
+            this._onError(failure);
+        } else {
+            this._commitError(APIService.getFirstErrorFromFailure(failure));
+        }
     };
 
     private _commitError = (error: BeebopError) => {
-      this._commit({ type: 'addError', payload: error });
+        this._commit({ type: "addError", payload: error });
     };
 
     private _verifyHandlers(url: string) {
-      if (this._onError == null && !this._ignoreErrors) {
-        console.warn(`No error handler registered for request ${url}.`);
-      }
-      if (this._onSuccess == null && !this._ignoreSuccess) {
-        console.warn(`No success handler registered for request ${url}.`);
-      }
+        if (this._onError == null && !this._ignoreErrors) {
+            console.warn(`No error handler registered for request ${url}.`);
+        }
+        if (this._onSuccess == null && !this._ignoreSuccess) {
+            console.warn(`No success handler registered for request ${url}.`);
+        }
     }
 
     async get<T>(url: string): Promise<void | ResponseWithType<T>> {
-      this._verifyHandlers(url);
-      return this._handleAxiosResponse(axios.get(url));
+        this._verifyHandlers(url);
+        return this._handleAxiosResponse(axios.get(url));
     }
 
     async post<T>(url: string, body: any): Promise<void | ResponseWithType<T>> {
-      this._verifyHandlers(url);
-      const headers = { 'Content-Type': 'application/json' };
-      return this._handleAxiosResponse(axios.post(url, body, { headers }));
+        this._verifyHandlers(url);
+        const headers = { "Content-Type": "application/json" };
+        return this._handleAxiosResponse(axios.post(url, body, { headers }));
     }
 }
 

--- a/app/client/src/components/CytoscapeGraph.vue
+++ b/app/client/src/components/CytoscapeGraph.vue
@@ -5,75 +5,75 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import cytoscape from 'cytoscape';
-import graphml from 'cytoscape-graphml';
-import jquery from 'jquery';
-import { mapState, mapActions } from 'vuex';
-import { CyGraphml } from '../types';
+import { defineComponent } from "vue";
+import cytoscape from "cytoscape";
+import graphml from "cytoscape-graphml";
+import jquery from "jquery";
+import { mapState, mapActions } from "vuex";
+import { CyGraphml } from "../types";
 
 export default defineComponent({
-  name: 'CytoscapeGraph',
-  props: ['cluster'],
-  mounted() {
-    graphml(cytoscape, jquery);
-    this.drawGraph();
-  },
-  computed: {
-    ...mapState(['results']),
-  },
-  methods: {
-    ...mapActions(['getGraphml']),
-    async drawGraph() {
-      if (!this.results.perCluster[this.cluster] || !this.results.perCluster[this.cluster].graph) {
-        await this.getGraphml(this.cluster);
-      }
-      const { graph } : {graph : string} = this.results.perCluster[this.cluster];
-      const cy = cytoscape({
-        container: this.$refs.cy as HTMLElement,
-        style: [
-          {
-            selector: 'node',
-            style: {
-              width: '10px',
-              height: '10px',
-              content: 'data(key0)',
-              'font-size': '7px',
-              'background-color': 'darkblue',
-              'border-style': 'solid',
-            },
-          },
-          {
-            selector: 'node[ref_query = "query"]',
-            style: {
-              'border-color': 'red',
-              'border-width': '2px',
-            },
-          },
-          {
-            selector: 'node[ref_query = "ref"]',
-            style: {
-              'border-color': 'black',
-              'border-width': '1px',
-            },
-          },
-          {
-            selector: 'edge',
-            style: {
-              width: '2px',
-              'line-color': 'steelblue',
-            },
-          },
-        ],
-        layout: {
-          name: 'grid',
-        },
-      });
-      cy.ready(() => {
-        (cy as CyGraphml).graphml({ layoutBy: 'cose' });
-        (cy as CyGraphml).graphml(graph);
-      });
+    name: "CytoscapeGraph",
+    props: ["cluster"],
+    mounted() {
+        graphml(cytoscape, jquery);
+        this.drawGraph();
     },
-  },
+    computed: {
+        ...mapState(["results"])
+    },
+    methods: {
+        ...mapActions(["getGraphml"]),
+        async drawGraph() {
+            if (!this.results.perCluster[this.cluster] || !this.results.perCluster[this.cluster].graph) {
+                await this.getGraphml(this.cluster);
+            }
+            const { graph } : {graph : string} = this.results.perCluster[this.cluster];
+            const cy = cytoscape({
+                container: this.$refs.cy as HTMLElement,
+                style: [
+                    {
+                        selector: "node",
+                        style: {
+                            width: "10px",
+                            height: "10px",
+                            content: "data(key0)",
+                            "font-size": "7px",
+                            "background-color": "darkblue",
+                            "border-style": "solid"
+                        }
+                    },
+                    {
+                        selector: 'node[ref_query = "query"]',
+                        style: {
+                            "border-color": "red",
+                            "border-width": "2px"
+                        }
+                    },
+                    {
+                        selector: 'node[ref_query = "ref"]',
+                        style: {
+                            "border-color": "black",
+                            "border-width": "1px"
+                        }
+                    },
+                    {
+                        selector: "edge",
+                        style: {
+                            width: "2px",
+                            "line-color": "steelblue"
+                        }
+                    }
+                ],
+                layout: {
+                    name: "grid"
+                }
+            });
+            cy.ready(() => {
+                (cy as CyGraphml).graphml({ layoutBy: "cose" });
+                (cy as CyGraphml).graphml(graph);
+            });
+        }
+    }
 });
 </script>

--- a/app/client/src/components/DownloadZip.vue
+++ b/app/client/src/components/DownloadZip.vue
@@ -7,20 +7,20 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapState, mapActions } from 'vuex';
+import { defineComponent } from "vue";
+import { mapState, mapActions } from "vuex";
 
 export default defineComponent({
-  name: 'DownloadZip',
-  props: ['type', 'cluster'],
-  methods: {
-    ...mapActions(['getZip']),
-    async onClick() {
-      this.getZip({ type: this.type, cluster: this.cluster });
+    name: "DownloadZip",
+    props: ["type", "cluster"],
+    methods: {
+        ...mapActions(["getZip"]),
+        async onClick() {
+            this.getZip({ type: this.type, cluster: this.cluster });
+        }
     },
-  },
-  computed: {
-    ...mapState(['projectHash']),
-  },
+    computed: {
+        ...mapState(["projectHash"])
+    }
 });
 </script>

--- a/app/client/src/components/DropZone.vue
+++ b/app/client/src/components/DropZone.vue
@@ -11,28 +11,28 @@
 </template>
 
 <script>
-import { useDropzone } from 'vue3-dropzone';
-import { useActions, useState } from 'vuex-composition-helpers';
+import { useDropzone } from "vue3-dropzone";
+import { useActions, useState } from "vuex-composition-helpers";
 
 export default {
-  name: 'DropZone',
-  setup() {
-    const { processFiles } = useActions(['processFiles']);
-    const { results } = useState(['results']);
-    function onDrop(acceptFiles) {
-      processFiles(acceptFiles);
+    name: "DropZone",
+    setup() {
+        const { processFiles } = useActions(["processFiles"]);
+        const { results } = useState(["results"]);
+        function onDrop(acceptFiles) {
+            processFiles(acceptFiles);
+        }
+        const {
+            getRootProps, getInputProps, isDragActive, ...rest
+        } = useDropzone({ onDrop, accept: [".fa", ".fasta"] });
+        return {
+            getRootProps,
+            getInputProps,
+            isDragActive,
+            onDrop,
+            results,
+            ...rest
+        };
     }
-    const {
-      getRootProps, getInputProps, isDragActive, ...rest
-    } = useDropzone({ onDrop, accept: ['.fa', '.fasta'] });
-    return {
-      getRootProps,
-      getInputProps,
-      isDragActive,
-      onDrop,
-      results,
-      ...rest,
-    };
-  },
 };
 </script>

--- a/app/client/src/components/GenerateMicroreactURL.vue
+++ b/app/client/src/components/GenerateMicroreactURL.vue
@@ -79,46 +79,46 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapState, mapActions } from 'vuex';
-import Modal from '@/components/Modal.vue';
-import { BeebopError, Errors } from '../types';
+import { defineComponent } from "vue";
+import { mapState, mapActions } from "vuex";
+import Modal from "@/components/Modal.vue";
+import { BeebopError, Errors } from "../types";
 
 export default defineComponent({
-  name: 'GenerateMicroreactURL',
-  props: ['cluster'],
-  components: {
-    Modal,
-  },
-  data() {
-    return {
-      isModalVisible: false,
-      token: null,
-    };
-  },
-  methods: {
-    ...mapActions(['buildMicroreactURL']),
-    showModal() {
-      this.isModalVisible = true;
+    name: "GenerateMicroreactURL",
+    props: ["cluster"],
+    components: {
+        Modal
     },
-    closeModal() {
-      this.isModalVisible = false;
+    data() {
+        return {
+            isModalVisible: false,
+            token: null
+        };
     },
-    saveToken() {
-      this.buildMicroreactURL({ cluster: this.cluster, token: this.token });
+    methods: {
+        ...mapActions(["buildMicroreactURL"]),
+        showModal() {
+            this.isModalVisible = true;
+        },
+        closeModal() {
+            this.isModalVisible = false;
+        },
+        saveToken() {
+            this.buildMicroreactURL({ cluster: this.cluster, token: this.token });
+        }
     },
-  },
-  computed: {
-    ...mapState(['results', 'microreactToken', 'errors']),
-    tokenWasWrong() {
-      return this.errors.some((e: BeebopError) => e.error === Errors.WRONG_TOKEN);
-    },
-    tokenAvailable() {
-      return this.microreactToken && !this.results.perCluster[this.cluster]?.microreactURL;
-    },
-    URLgenerated() {
-      return this.microreactToken && this.results.perCluster[this.cluster]?.microreactURL;
-    },
-  },
+    computed: {
+        ...mapState(["results", "microreactToken", "errors"]),
+        tokenWasWrong() {
+            return this.errors.some((e: BeebopError) => e.error === Errors.WRONG_TOKEN);
+        },
+        tokenAvailable() {
+            return this.microreactToken && !this.results.perCluster[this.cluster]?.microreactURL;
+        },
+        URLgenerated() {
+            return this.microreactToken && this.results.perCluster[this.cluster]?.microreactURL;
+        }
+    }
 });
 </script>

--- a/app/client/src/components/LoginPrompt.vue
+++ b/app/client/src/components/LoginPrompt.vue
@@ -10,18 +10,18 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import config from '@settings/config';
+import { defineComponent } from "vue";
+import config from "@settings/config";
 
 export default defineComponent({
-  computed: {
-    generateLoginGoogle() {
-      return `${config.serverUrl()}/login/google`;
-    },
-    generateLoginGithub() {
-      return `${config.serverUrl()}/login/github`;
-    },
-  },
+    computed: {
+        generateLoginGoogle() {
+            return `${config.serverUrl()}/login/google`;
+        },
+        generateLoginGithub() {
+            return `${config.serverUrl()}/login/github`;
+        }
+    }
 });
 </script>
 

--- a/app/client/src/components/Modal.vue
+++ b/app/client/src/components/Modal.vue
@@ -20,6 +20,6 @@
 
 <script lang="ts">
 export default {
-  name: 'ModalTemplate',
+    name: "ModalTemplate"
 };
 </script>

--- a/app/client/src/components/NavbarDropdown.vue
+++ b/app/client/src/components/NavbarDropdown.vue
@@ -28,24 +28,24 @@
 </template>
 
 <script lang="ts">
-import { mapState } from 'vuex';
-import config from '@settings/config';
-import { RouterLink } from 'vue-router';
+import { mapState } from "vuex";
+import config from "@settings/config";
+import { RouterLink } from "vue-router";
 
 export default {
-  name: 'NavbarDropdown',
-  components: {
-    RouterLink,
-  },
-  computed: {
-    generateLogout() {
-      return `${config.serverUrl()}/logout`;
+    name: "NavbarDropdown",
+    components: {
+        RouterLink
     },
-    ...mapState(['user']),
-    loggedInText() {
-      return this.user ? `Logged in as ${this.user.name}` : '';
-    },
-  },
+    computed: {
+        generateLogout() {
+            return `${config.serverUrl()}/logout`;
+        },
+        ...mapState(["user"]),
+        loggedInText() {
+            return this.user ? `Logged in as ${this.user.name}` : "";
+        }
+    }
 };
 </script>
 

--- a/app/client/src/components/NetworkVisualisations.vue
+++ b/app/client/src/components/NetworkVisualisations.vue
@@ -33,34 +33,34 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapGetters } from 'vuex';
-import CytoscapeGraph from '@/components/CytoscapeGraph.vue';
+import { defineComponent } from "vue";
+import { mapGetters } from "vuex";
+import CytoscapeGraph from "@/components/CytoscapeGraph.vue";
 
 export default defineComponent({
-  name: 'NetworkVisualisations',
-  props: ['firstCluster'],
-  data() {
-    return {
-      visitedTabs: [this.firstCluster],
-      selectedCluster: this.firstCluster,
-    };
-  },
-  components: {
-    CytoscapeGraph,
-  },
-  computed: {
-    ...mapGetters([
-      'uniqueClusters',
-    ]),
-  },
-  methods: {
-    onInput(value: number) {
-      this.selectedCluster = value;
-      if (!this.visitedTabs.includes(value)) {
-        this.visitedTabs.push(value);
-      }
+    name: "NetworkVisualisations",
+    props: ["firstCluster"],
+    data() {
+        return {
+            visitedTabs: [this.firstCluster],
+            selectedCluster: this.firstCluster
+        };
     },
-  },
+    components: {
+        CytoscapeGraph
+    },
+    computed: {
+        ...mapGetters([
+            "uniqueClusters"
+        ])
+    },
+    methods: {
+        onInput(value: number) {
+            this.selectedCluster = value;
+            if (!this.visitedTabs.includes(value)) {
+                this.visitedTabs.push(value);
+            }
+        }
+    }
 });
 </script>

--- a/app/client/src/components/ProgressBar.vue
+++ b/app/client/src/components/ProgressBar.vue
@@ -13,23 +13,23 @@
 </template>
 
 <script lang="ts">
-import { mapGetters } from 'vuex';
-import { BProgress, BProgressBar } from 'bootstrap-vue-3';
-import { defineComponent } from 'vue';
+import { mapGetters } from "vuex";
+import { BProgress, BProgressBar } from "bootstrap-vue-3";
+import { defineComponent } from "vue";
 
 export default defineComponent({
-  name: 'ProgressBar',
-  computed: {
-    ...mapGetters([
-      'analysisProgress',
-    ]),
-    animated(): boolean {
-      return this.analysisProgress.progress !== 1;
+    name: "ProgressBar",
+    computed: {
+        ...mapGetters([
+            "analysisProgress"
+        ]),
+        animated(): boolean {
+            return this.analysisProgress.progress !== 1;
+        }
     },
-  },
-  components: {
-    BProgress,
-    BProgressBar,
-  },
+    components: {
+        BProgress,
+        BProgressBar
+    }
 });
 </script>

--- a/app/client/src/components/ResultsTable.vue
+++ b/app/client/src/components/ResultsTable.vue
@@ -66,71 +66,71 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapState } from 'vuex';
-import { VBTooltip } from 'bootstrap-vue-3';
+import { defineComponent } from "vue";
+import { mapState } from "vuex";
+import { VBTooltip } from "bootstrap-vue-3";
 import {
-  addRowspan, getRGB, tooltipLine,
-} from '../utils';
-import DownloadZip from './DownloadZip.vue';
-import GenerateMicroreactURL from './GenerateMicroreactURL.vue';
+    addRowspan, getRGB, tooltipLine
+} from "../utils";
+import DownloadZip from "./DownloadZip.vue";
+import GenerateMicroreactURL from "./GenerateMicroreactURL.vue";
 
 export default defineComponent({
-  name: 'ResultsTable',
-  directives: {
-    'b-tooltip': VBTooltip,
-  },
-  components: {
-    DownloadZip,
-    GenerateMicroreactURL,
-  },
-  methods: {
-    getRGB,
-    tooltipLine,
-    getTooltipText(data: Record<string, number>) {
-      const firstLine = 'Probability of resistance to:';
-      const pen = this.tooltipLine('Penicillin', data.Penicillin);
-      const chlor = this.tooltipLine('Chloramphenicol', data.Chloramphenicol);
-      const ery = this.tooltipLine('Erythromycin', data.Erythromycin);
-      const tetra = this.tooltipLine('Tetracycline', data.Tetracycline);
-      const cotrim = this.tooltipLine('Cotrim', data.Trim_sulfa);
-      return [firstLine, pen, chlor, ery, tetra, cotrim].join('<br/>');
+    name: "ResultsTable",
+    directives: {
+        "b-tooltip": VBTooltip
     },
-    getCluster(sample: string) {
-      return (this.results.perIsolate[sample].cluster
-        ? this.results.perIsolate[sample].cluster : this.analysisStatus.assign);
+    components: {
+        DownloadZip,
+        GenerateMicroreactURL
     },
-    getMicroreact() {
-      return (this.analysisStatus.microreact === 'finished') ? 'showButton' : this.analysisStatus.microreact;
+    methods: {
+        getRGB,
+        tooltipLine,
+        getTooltipText(data: Record<string, number>) {
+            const firstLine = "Probability of resistance to:";
+            const pen = this.tooltipLine("Penicillin", data.Penicillin);
+            const chlor = this.tooltipLine("Chloramphenicol", data.Chloramphenicol);
+            const ery = this.tooltipLine("Erythromycin", data.Erythromycin);
+            const tetra = this.tooltipLine("Tetracycline", data.Tetracycline);
+            const cotrim = this.tooltipLine("Cotrim", data.Trim_sulfa);
+            return [firstLine, pen, chlor, ery, tetra, cotrim].join("<br/>");
+        },
+        getCluster(sample: string) {
+            return (this.results.perIsolate[sample].cluster
+                ? this.results.perIsolate[sample].cluster : this.analysisStatus.assign);
+        },
+        getMicroreact() {
+            return (this.analysisStatus.microreact === "finished") ? "showButton" : this.analysisStatus.microreact;
+        },
+        getNetwork() {
+            return (this.analysisStatus.network === "finished") ? "showButton" : this.analysisStatus.network;
+        }
     },
-    getNetwork() {
-      return (this.analysisStatus.network === 'finished') ? 'showButton' : this.analysisStatus.network;
-    },
-  },
-  computed: {
-    ...mapState(['results', 'submitStatus', 'analysisStatus']),
-    tableData() {
-      const samples = this.results.perIsolate;
-      const items: Record<string, string | number>[] = [];
-      Object.keys(samples).forEach((sample) => {
-        items.push({
-          Hash: samples[sample].hash,
-          Filename: samples[sample].filename,
-          Sketch: (samples[sample].sketch) ? '\u2714' : 'processing',
-          AMR: samples[sample].amr ? samples[sample].amr : 'processing',
-          Cluster: this.submitStatus === 'submitted' ? this.getCluster(sample) : '',
-          Microreact: this.submitStatus === 'submitted' ? this.getMicroreact() : '',
-          Network: this.submitStatus === 'submitted' ? this.getNetwork() : '',
-        });
-      });
-      const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
-      if (this.analysisStatus.assign === 'finished') {
-        // adding a rowspan property to merge microreact/ network cells from same cluster
-        const tableRowspan = addRowspan(tableSorted);
-        return tableRowspan;
-      }
-      return tableSorted;
-    },
-  },
+    computed: {
+        ...mapState(["results", "submitStatus", "analysisStatus"]),
+        tableData() {
+            const samples = this.results.perIsolate;
+            const items: Record<string, string | number>[] = [];
+            Object.keys(samples).forEach((sample) => {
+                items.push({
+                    Hash: samples[sample].hash,
+                    Filename: samples[sample].filename,
+                    Sketch: (samples[sample].sketch) ? "\u2714" : "processing",
+                    AMR: samples[sample].amr ? samples[sample].amr : "processing",
+                    Cluster: this.submitStatus === "submitted" ? this.getCluster(sample) : "",
+                    Microreact: this.submitStatus === "submitted" ? this.getMicroreact() : "",
+                    Network: this.submitStatus === "submitted" ? this.getNetwork() : ""
+                });
+            });
+            const tableSorted = items.sort((a, b) => Number(a.Cluster) - Number(b.Cluster));
+            if (this.analysisStatus.assign === "finished") {
+                // adding a rowspan property to merge microreact/ network cells from same cluster
+                const tableRowspan = addRowspan(tableSorted);
+                return tableRowspan;
+            }
+            return tableSorted;
+        }
+    }
 });
 </script>

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -22,28 +22,28 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapActions, mapMutations } from 'vuex';
+import { defineComponent } from "vue";
+import { mapActions, mapMutations } from "vuex";
 
 export default defineComponent({
-  name: 'SelectAction',
-  data() {
-    return {
-      projectName: '',
-    };
-  },
-  mounted() {
-    this.getUser();
-  },
-  methods: {
-    ...mapActions(['getUser']),
-    ...mapMutations(['setProjectName']),
-    runAnalysis() {
-      if (this.projectName) {
-        this.setProjectName(this.projectName);
-        this.$router.push('/project');
-      }
+    name: "SelectAction",
+    data() {
+        return {
+            projectName: ""
+        };
     },
-  },
+    mounted() {
+        this.getUser();
+    },
+    methods: {
+        ...mapActions(["getUser"]),
+        ...mapMutations(["setProjectName"]),
+        runAnalysis() {
+            if (this.projectName) {
+                this.setProjectName(this.projectName);
+                this.$router.push("/project");
+            }
+        }
+    }
 });
 </script>

--- a/app/client/src/components/StartButton.vue
+++ b/app/client/src/components/StartButton.vue
@@ -8,24 +8,24 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapActions, mapState } from 'vuex';
+import { defineComponent } from "vue";
+import { mapActions, mapState } from "vuex";
 
 export default defineComponent({
-  name: 'StartButton',
-  methods: {
-    ...mapActions(['submitData']),
-    onClick() {
-      this.submitData();
+    name: "StartButton",
+    methods: {
+        ...mapActions(["submitData"]),
+        onClick() {
+            this.submitData();
+        }
     },
-  },
-  computed: {
-    ...mapState(['submitStatus', 'analysisStatus', 'results']),
-    allSketched(): boolean {
-      const isolates = this.results.perIsolate;
-      const keys = Object.keys(isolates);
-      return !!keys.length && keys.every((el: string) => isolates[el].sketch);
-    },
-  },
+    computed: {
+        ...mapState(["submitStatus", "analysisStatus", "results"]),
+        allSketched(): boolean {
+            const isolates = this.results.perIsolate;
+            const keys = Object.keys(isolates);
+            return !!keys.length && keys.every((el: string) => isolates[el].sketch);
+        }
+    }
 });
 </script>

--- a/app/client/src/components/VersionInfo.vue
+++ b/app/client/src/components/VersionInfo.vue
@@ -10,21 +10,21 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import { mapState, mapActions } from 'vuex';
+import { defineComponent } from "vue";
+import { mapState, mapActions } from "vuex";
 
 export default defineComponent({
-  name: 'VersionInfo',
-  mounted() {
-    this.getVersions();
-  },
-  methods: {
-    ...mapActions([
-      'getVersions',
-    ]),
-  },
-  computed: mapState([
-    'versions',
-  ]),
+    name: "VersionInfo",
+    mounted() {
+        this.getVersions();
+    },
+    methods: {
+        ...mapActions([
+            "getVersions"
+        ])
+    },
+    computed: mapState([
+        "versions"
+    ])
 });
 </script>

--- a/app/client/src/main.ts
+++ b/app/client/src/main.ts
@@ -1,6 +1,6 @@
-import { createApp } from 'vue';
-import App from './App.vue';
-import router from './router';
-import store from './store';
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
+import store from "./store";
 
-createApp(App).use(store).use(router).mount('#app');
+createApp(App).use(store).use(router).mount("#app");

--- a/app/client/src/router/index.ts
+++ b/app/client/src/router/index.ts
@@ -1,29 +1,29 @@
-import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
-import HomeView from '../views/HomeView.vue';
-import ProjectView from '../views/ProjectView.vue';
-import AboutView from '../views/AboutView.vue';
+import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import HomeView from "../views/HomeView.vue";
+import ProjectView from "../views/ProjectView.vue";
+import AboutView from "../views/AboutView.vue";
 
 const routes: Array<RouteRecordRaw> = [
-  {
-    path: '/',
-    name: 'home',
-    component: HomeView,
-  },
-  {
-    path: '/about',
-    name: 'about',
-    component: AboutView,
-  },
-  {
-    path: '/project',
-    name: 'project',
-    component: ProjectView,
-  },
+    {
+        path: "/",
+        name: "home",
+        component: HomeView
+    },
+    {
+        path: "/about",
+        name: "about",
+        component: AboutView
+    },
+    {
+        path: "/project",
+        name: "project",
+        component: ProjectView
+    }
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
-  routes,
+    history: createWebHistory(),
+    routes
 });
 
 export default router;

--- a/app/client/src/settings/development/config.ts
+++ b/app/client/src/settings/development/config.ts
@@ -1,4 +1,4 @@
 export default {
-  serverUrl: () => 'http://localhost:4000',
-  clientUrl: () => 'http://localhost:8080',
+    serverUrl: () => "http://localhost:4000",
+    clientUrl: () => "http://localhost:8080"
 };

--- a/app/client/src/settings/docker/config.ts
+++ b/app/client/src/settings/docker/config.ts
@@ -1,4 +1,4 @@
 export default {
-  serverUrl: () => `https://${window.location.host}/api`,
-  clientUrl: () => `https://${window.location.host}`,
+    serverUrl: () => `https://${window.location.host}/api`,
+    clientUrl: () => `https://${window.location.host}`
 };

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -1,177 +1,177 @@
-import axios from 'axios';
-import { Commit, ActionContext } from 'vuex';
-import config from '@settings/config';
-import { Md5 } from 'ts-md5/dist/md5';
-import { RootState } from '@/store/state';
+import axios from "axios";
+import { Commit, ActionContext } from "vuex";
+import config from "@settings/config";
+import { Md5 } from "ts-md5/dist/md5";
+import { RootState } from "@/store/state";
 import {
-  Versions, User, AnalysisStatus, ClusterInfo, Dict,
-} from '@/types';
-import { api } from '@/apiService';
+    Versions, User, AnalysisStatus, ClusterInfo, Dict
+} from "@/types";
+import { api } from "@/apiService";
 
 axios.defaults.withCredentials = true;
 const serverUrl = config.serverUrl();
 
 export default {
-  async getVersions(context: ActionContext<RootState, RootState>) {
-    await api(context)
-      .withSuccess('setVersions')
-      .withError('addError')
-      .get<Versions>(`${serverUrl}/version`);
-  },
-  async getUser(context: ActionContext<RootState, RootState>) {
-    await api(context)
-      .withSuccess('setUser')
-      .withError('addError')
-      .get<User>(`${serverUrl}/user`);
-  },
-  async logoutUser() {
-    await axios.get(`${serverUrl}/logout`);
-  },
-  async processFiles({ commit } : { commit: Commit }, acceptFiles: Array<File>) {
-    function readContent(file: File) {
-      return file.text();
-    }
-    acceptFiles.forEach((file: File) => {
-      readContent(file)
-        .then((content: string) => {
-          const fileHash = Md5.hashStr(content);
-          commit('addFile', { hash: fileHash, name: file.name });
-          const worker = new Worker('./worker.js');
-          worker.onmessage = (event) => {
-            commit('setIsolateValue', event.data);
-          };
-          worker.postMessage({ hash: fileHash, fileObject: file });
+    async getVersions(context: ActionContext<RootState, RootState>) {
+        await api(context)
+            .withSuccess("setVersions")
+            .withError("addError")
+            .get<Versions>(`${serverUrl}/version`);
+    },
+    async getUser(context: ActionContext<RootState, RootState>) {
+        await api(context)
+            .withSuccess("setUser")
+            .withError("addError")
+            .get<User>(`${serverUrl}/user`);
+    },
+    async logoutUser() {
+        await axios.get(`${serverUrl}/logout`);
+    },
+    async processFiles({ commit } : { commit: Commit }, acceptFiles: Array<File>) {
+        function readContent(file: File) {
+            return file.text();
+        }
+        acceptFiles.forEach((file: File) => {
+            readContent(file)
+                .then((content: string) => {
+                    const fileHash = Md5.hashStr(content);
+                    commit("addFile", { hash: fileHash, name: file.name });
+                    const worker = new Worker("./worker.js");
+                    worker.onmessage = (event) => {
+                        commit("setIsolateValue", event.data);
+                    };
+                    worker.postMessage({ hash: fileHash, fileObject: file });
+                });
         });
-    });
-  },
-  async runPoppunk(context: ActionContext<RootState, RootState>) {
-    const { state, commit } = context;
-    // generate filenameMapping that the backend can use to replace
-    // filehashes with filenames in results.
-    // Also generate a string of ordered hashes and corresponding filenames
-    // to be used to generate a projecthash that is unique to this combination
-    // of file contents and filenames
-    const filenameMapping = {} as Dict<string>;
-    let mappingOrdered = '';
-    Object.keys(state.results.perIsolate).sort().forEach((filehash) => {
-      // disabling this rule here since this should always have a value
-      // since the action can only be triggered when files have been uploaded:
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      filenameMapping[filehash] = state.results.perIsolate[filehash].filename!;
-      mappingOrdered += filehash;
-      mappingOrdered += state.results.perIsolate[filehash].filename;
-    });
-    const phash = Md5.hashStr(mappingOrdered);
-    commit('setProjectHash', phash);
-    // add all sketches to object
-    const jsonSketches = {} as Dict<Dict<string>>;
-    Object.keys(state.results.perIsolate).forEach((element) => {
-      jsonSketches[element] = JSON.parse(state.results.perIsolate[element].sketch as string);
-    });
-    const response = await api(context)
-      .withError('addError')
-      .ignoreSuccess()
-      .post<AnalysisStatus>(`${serverUrl}/poppunk`, {
-        projectHash: phash,
-        projectName: state.projectName,
-        sketches: jsonSketches,
-        names: filenameMapping,
-      });
-    if (response) {
-      commit('setAnalysisStatus', { assign: 'submitted', microreact: 'submitted', network: 'submitted' });
+    },
+    async runPoppunk(context: ActionContext<RootState, RootState>) {
+        const { state, commit } = context;
+        // generate filenameMapping that the backend can use to replace
+        // filehashes with filenames in results.
+        // Also generate a string of ordered hashes and corresponding filenames
+        // to be used to generate a projecthash that is unique to this combination
+        // of file contents and filenames
+        const filenameMapping = {} as Dict<string>;
+        let mappingOrdered = "";
+        Object.keys(state.results.perIsolate).sort().forEach((filehash) => {
+            // disabling this rule here since this should always have a value
+            // since the action can only be triggered when files have been uploaded:
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            filenameMapping[filehash] = state.results.perIsolate[filehash].filename!;
+            mappingOrdered += filehash;
+            mappingOrdered += state.results.perIsolate[filehash].filename;
+        });
+        const phash = Md5.hashStr(mappingOrdered);
+        commit("setProjectHash", phash);
+        // add all sketches to object
+        const jsonSketches = {} as Dict<Dict<string>>;
+        Object.keys(state.results.perIsolate).forEach((element) => {
+            jsonSketches[element] = JSON.parse(state.results.perIsolate[element].sketch as string);
+        });
+        const response = await api(context)
+            .withError("addError")
+            .ignoreSuccess()
+            .post<AnalysisStatus>(`${serverUrl}/poppunk`, {
+                projectHash: phash,
+                projectName: state.projectName,
+                sketches: jsonSketches,
+                names: filenameMapping
+            });
+        if (response) {
+            commit("setAnalysisStatus", { assign: "submitted", microreact: "submitted", network: "submitted" });
+        }
+    },
+    async getStatus(context: ActionContext<RootState, RootState>) {
+        const { state, dispatch } = context;
+        const prevAssign = state.analysisStatus.assign;
+        const response = await api(context)
+            .withSuccess("setAnalysisStatus")
+            .withError("addError")
+            .post<AnalysisStatus>(`${serverUrl}/status`, { hash: state.projectHash });
+        if (response) {
+            if (response.data.assign === "finished" && prevAssign !== "finished") {
+                dispatch("getAssignResult");
+            }
+            if ((response.data.network === "finished" || response.data.network === "failed")
+        && (response.data.microreact === "finished" || response.data.microreact === "failed")) {
+                clearInterval(state.statusInterval);
+            }
+        }
+        if (!response) {
+            clearInterval(state.statusInterval);
+        }
+    },
+    async getAssignResult(context: ActionContext<RootState, RootState>) {
+        const { state } = context;
+        await api(context)
+            .withSuccess("setClusters")
+            .withError("addError")
+            .post<ClusterInfo>(`${serverUrl}/assignResult`, { projectHash: state.projectHash });
+    },
+    async startStatusPolling(context: ActionContext<RootState, RootState>) {
+        const { dispatch, commit } = context;
+        const inter = setInterval(() => { dispatch("getStatus"); }, 1000);
+        commit("setStatusInterval", inter);
+    },
+    async submitData(context: ActionContext<RootState, RootState>) {
+        const { dispatch, commit } = context;
+        await dispatch("runPoppunk");
+        commit("setSubmitStatus", "submitted");
+        dispatch("startStatusPolling");
+    },
+    async getZip(
+        context: ActionContext<RootState, RootState>,
+        data: Record<string, string | number>
+    ) {
+        const { state } = context;
+        await axios.post(
+            `${serverUrl}/downloadZip`,
+            {
+                type: data.type,
+                cluster: data.cluster,
+                projectHash: state.projectHash
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                responseType: "arraybuffer"
+            }
+        )
+            .then((response) => {
+                const blob = new Blob([response.data], { type: "application/zip" });
+                const link = document.createElement("a");
+                link.href = window.URL.createObjectURL(blob);
+                link.download = `${data.type}_cluster${data.cluster}.zip`;
+                link.click();
+            });
+    },
+    async buildMicroreactURL(
+        context: ActionContext<RootState, RootState>,
+        data: Record<string, string | number>
+    ) {
+        const { state, commit } = context;
+        commit("setToken", data.token);
+        await api(context)
+            .withSuccess("addMicroreactURL")
+            .withError("addError")
+            .post<ClusterInfo>(`${serverUrl}/microreactURL`, {
+                cluster: data.cluster,
+                projectHash: state.projectHash,
+                apiToken: state.microreactToken
+            });
+    },
+    async getGraphml(
+        context: ActionContext<RootState, RootState>,
+        cluster: string | number
+    ) {
+        const { state } = context;
+        await api(context)
+            .withSuccess("addGraphml")
+            .withError("addError")
+            .post<ClusterInfo>(`${serverUrl}/downloadGraphml`, {
+                cluster,
+                projectHash: state.projectHash
+            });
     }
-  },
-  async getStatus(context: ActionContext<RootState, RootState>) {
-    const { state, dispatch } = context;
-    const prevAssign = state.analysisStatus.assign;
-    const response = await api(context)
-      .withSuccess('setAnalysisStatus')
-      .withError('addError')
-      .post<AnalysisStatus>(`${serverUrl}/status`, { hash: state.projectHash });
-    if (response) {
-      if (response.data.assign === 'finished' && prevAssign !== 'finished') {
-        dispatch('getAssignResult');
-      }
-      if ((response.data.network === 'finished' || response.data.network === 'failed')
-        && (response.data.microreact === 'finished' || response.data.microreact === 'failed')) {
-        clearInterval(state.statusInterval);
-      }
-    }
-    if (!response) {
-      clearInterval(state.statusInterval);
-    }
-  },
-  async getAssignResult(context: ActionContext<RootState, RootState>) {
-    const { state } = context;
-    await api(context)
-      .withSuccess('setClusters')
-      .withError('addError')
-      .post<ClusterInfo>(`${serverUrl}/assignResult`, { projectHash: state.projectHash });
-  },
-  async startStatusPolling(context: ActionContext<RootState, RootState>) {
-    const { dispatch, commit } = context;
-    const inter = setInterval(() => { dispatch('getStatus'); }, 1000);
-    commit('setStatusInterval', inter);
-  },
-  async submitData(context: ActionContext<RootState, RootState>) {
-    const { dispatch, commit } = context;
-    await dispatch('runPoppunk');
-    commit('setSubmitStatus', 'submitted');
-    dispatch('startStatusPolling');
-  },
-  async getZip(
-    context: ActionContext<RootState, RootState>,
-    data: Record<string, string | number>,
-  ) {
-    const { state } = context;
-    await axios.post(
-      `${serverUrl}/downloadZip`,
-      {
-        type: data.type,
-        cluster: data.cluster,
-        projectHash: state.projectHash,
-      },
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        responseType: 'arraybuffer',
-      },
-    )
-      .then((response) => {
-        const blob = new Blob([response.data], { type: 'application/zip' });
-        const link = document.createElement('a');
-        link.href = window.URL.createObjectURL(blob);
-        link.download = `${data.type}_cluster${data.cluster}.zip`;
-        link.click();
-      });
-  },
-  async buildMicroreactURL(
-    context: ActionContext<RootState, RootState>,
-    data: Record<string, string | number>,
-  ) {
-    const { state, commit } = context;
-    commit('setToken', data.token);
-    await api(context)
-      .withSuccess('addMicroreactURL')
-      .withError('addError')
-      .post<ClusterInfo>(`${serverUrl}/microreactURL`, {
-        cluster: data.cluster,
-        projectHash: state.projectHash,
-        apiToken: state.microreactToken,
-      });
-  },
-  async getGraphml(
-    context: ActionContext<RootState, RootState>,
-    cluster: string | number,
-  ) {
-    const { state } = context;
-    await api(context)
-      .withSuccess('addGraphml')
-      .withError('addError')
-      .post<ClusterInfo>(`${serverUrl}/downloadGraphml`, {
-        cluster,
-        projectHash: state.projectHash,
-      });
-  },
 };

--- a/app/client/src/store/getters.ts
+++ b/app/client/src/store/getters.ts
@@ -1,10 +1,10 @@
-import { AnalysisType } from '@/types';
-import { Getter, GetterTree } from 'vuex';
-import { RootState } from '@/store/state';
+import { AnalysisType } from "@/types";
+import { Getter, GetterTree } from "vuex";
+import { RootState } from "@/store/state";
 
 export enum BeebopGetter {
-  analysisProgress = 'analysisProgress',
-  uniqueClusters = 'uniqueClusters'
+  analysisProgress = "analysisProgress",
+  uniqueClusters = "uniqueClusters"
 }
 
 export interface BeebopGetters {
@@ -12,26 +12,26 @@ export interface BeebopGetters {
 }
 
 export const getters: BeebopGetters & GetterTree<RootState, RootState> = {
-  [BeebopGetter.analysisProgress]: (
-    state: RootState,
-  ): Record<string, number> => {
-    let finished = 0;
-    const total = Object.keys(state.analysisStatus).length;
-    Object.keys(state.analysisStatus).forEach((element: string) => {
-      if (state.analysisStatus[element as AnalysisType] === 'finished') {
-        finished += 1;
-      }
-    });
-    return { total, finished, progress: (finished / total) };
-  },
+    [BeebopGetter.analysisProgress]: (
+        state: RootState
+    ): Record<string, number> => {
+        let finished = 0;
+        const total = Object.keys(state.analysisStatus).length;
+        Object.keys(state.analysisStatus).forEach((element: string) => {
+            if (state.analysisStatus[element as AnalysisType] === "finished") {
+                finished += 1;
+            }
+        });
+        return { total, finished, progress: (finished / total) };
+    },
 
-  [BeebopGetter.uniqueClusters]: (
-    state: RootState,
-  ): number[] => {
-    const clusters: number[] = [];
-    Object.keys(state.results.perIsolate).forEach((element: string) => {
-      clusters.push(state.results.perIsolate[element].cluster as number);
-    });
-    return [...new Set(clusters)].sort((a, b) => a - b);
-  },
+    [BeebopGetter.uniqueClusters]: (
+        state: RootState
+    ): number[] => {
+        const clusters: number[] = [];
+        Object.keys(state.results.perIsolate).forEach((element: string) => {
+            clusters.push(state.results.perIsolate[element].cluster as number);
+        });
+        return [...new Set(clusters)].sort((a, b) => a - b);
+    }
 };

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -1,32 +1,32 @@
-import Vuex from 'vuex';
-import actions from '@/store/actions';
-import mutations from '@/store/mutations';
-import { getters } from '@/store/getters';
-import { RootState } from '@/store/state';
+import Vuex from "vuex";
+import actions from "@/store/actions";
+import mutations from "@/store/mutations";
+import { getters } from "@/store/getters";
+import { RootState } from "@/store/state";
 
 export default new Vuex.Store<RootState>({
-  state: {
-    errors: [],
-    versions: [],
-    user: null,
-    microreactToken: null,
-    results: {
-      perIsolate: {},
-      perCluster: {},
+    state: {
+        errors: [],
+        versions: [],
+        user: null,
+        microreactToken: null,
+        results: {
+            perIsolate: {},
+            perCluster: {}
+        },
+        projectHash: null,
+        projectName: null,
+        submitStatus: null,
+        analysisStatus: {
+            assign: null,
+            microreact: null,
+            network: null
+        },
+        statusInterval: undefined
     },
-    projectHash: null,
-    projectName: null,
-    submitStatus: null,
-    analysisStatus: {
-      assign: null,
-      microreact: null,
-      network: null,
-    },
-    statusInterval: undefined,
-  },
-  getters,
-  mutations,
-  actions,
-  modules: {
-  },
+    getters,
+    mutations,
+    actions,
+    modules: {
+    }
 });

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -1,71 +1,71 @@
-import { RootState } from '@/store/state';
+import { RootState } from "@/store/state";
 import {
-  Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError,
-} from '@/types';
+    Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError
+} from "@/types";
 
 export default {
-  addError(state: RootState, payload: BeebopError) {
-    state.errors.push(payload);
-  },
-  setProjectName(state: RootState, projectName: string) {
-    state.projectName = projectName;
-  },
-  setVersions(state: RootState, versioninfo: Versions) {
-    state.versions = versioninfo;
-  },
-  setUser(state: RootState, userinfo: User) {
-    state.user = userinfo;
-  },
-  addFile(state: RootState, input: Record<string, string>) {
-    if (!state.results.perIsolate[input.hash]) {
-      state.results.perIsolate[input.hash] = {
-        hash: input.hash,
-        filename: input.name,
-      };
+    addError(state: RootState, payload: BeebopError) {
+        state.errors.push(payload);
+    },
+    setProjectName(state: RootState, projectName: string) {
+        state.projectName = projectName;
+    },
+    setVersions(state: RootState, versioninfo: Versions) {
+        state.versions = versioninfo;
+    },
+    setUser(state: RootState, userinfo: User) {
+        state.user = userinfo;
+    },
+    addFile(state: RootState, input: Record<string, string>) {
+        if (!state.results.perIsolate[input.hash]) {
+            state.results.perIsolate[input.hash] = {
+                hash: input.hash,
+                filename: input.name
+            };
+        }
+    },
+    setIsolateValue(state: RootState, input: IsolateValue) {
+        let results = null;
+        if (input.type === "amr") {
+            results = JSON.parse(input.result);
+        } else {
+            results = input.result;
+        }
+        state.results.perIsolate[input.hash][input.type] = results;
+    },
+    setProjectHash(state: RootState, phash: string) {
+        state.projectHash = phash;
+    },
+    setSubmitStatus(state: RootState, data: string) {
+        state.submitStatus = data;
+    },
+    setAnalysisStatus(state: RootState, data: AnalysisStatus) {
+        state.analysisStatus = data;
+    },
+    setStatusInterval(state: RootState, interval: number) {
+        state.statusInterval = interval;
+    },
+    setClusters(state: RootState, clusterInfo: ClusterInfo) {
+        Object.keys(clusterInfo).forEach((element) => {
+            state.results.perIsolate[clusterInfo[element].hash]
+                .cluster = clusterInfo[element].cluster;
+        });
+    },
+    addMicroreactURL(state: RootState, URLinfo: Record<string, string>) {
+        state.results.perCluster[URLinfo.cluster] = {
+            ...state.results.perCluster[URLinfo.cluster],
+            cluster: URLinfo.cluster,
+            microreactURL: URLinfo.url
+        };
+    },
+    setToken(state: RootState, token: string | null) {
+        state.microreactToken = token;
+    },
+    addGraphml(state: RootState, graphInfo: Record<string, string>) {
+        state.results.perCluster[graphInfo.cluster] = {
+            ...state.results.perCluster[graphInfo.cluster],
+            cluster: graphInfo.cluster,
+            graph: graphInfo.graph
+        };
     }
-  },
-  setIsolateValue(state: RootState, input: IsolateValue) {
-    let results = null;
-    if (input.type === 'amr') {
-      results = JSON.parse(input.result);
-    } else {
-      results = input.result;
-    }
-    state.results.perIsolate[input.hash][input.type] = results;
-  },
-  setProjectHash(state: RootState, phash: string) {
-    state.projectHash = phash;
-  },
-  setSubmitStatus(state: RootState, data: string) {
-    state.submitStatus = data;
-  },
-  setAnalysisStatus(state: RootState, data: AnalysisStatus) {
-    state.analysisStatus = data;
-  },
-  setStatusInterval(state: RootState, interval: number) {
-    state.statusInterval = interval;
-  },
-  setClusters(state: RootState, clusterInfo: ClusterInfo) {
-    Object.keys(clusterInfo).forEach((element) => {
-      state.results.perIsolate[clusterInfo[element].hash]
-        .cluster = clusterInfo[element].cluster;
-    });
-  },
-  addMicroreactURL(state: RootState, URLinfo: Record<string, string>) {
-    state.results.perCluster[URLinfo.cluster] = {
-      ...state.results.perCluster[URLinfo.cluster],
-      cluster: URLinfo.cluster,
-      microreactURL: URLinfo.url,
-    };
-  },
-  setToken(state: RootState, token: string | null) {
-    state.microreactToken = token;
-  },
-  addGraphml(state: RootState, graphInfo: Record<string, string>) {
-    state.results.perCluster[graphInfo.cluster] = {
-      ...state.results.perCluster[graphInfo.cluster],
-      cluster: graphInfo.cluster,
-      graph: graphInfo.graph,
-    };
-  },
 };

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -1,10 +1,10 @@
 import {
-  BeebopError,
-  Versions,
-  User,
-  Results,
-  AnalysisStatus,
-} from '@/types';
+    BeebopError,
+    Versions,
+    User,
+    Results,
+    AnalysisStatus
+} from "@/types";
 
 export interface RootState {
   errors: BeebopError[]

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -1,4 +1,4 @@
-import cytoscape from 'cytoscape';
+import cytoscape from "cytoscape";
 
 export type Dict<T> = Record<string, T>
 
@@ -26,8 +26,8 @@ export interface Results {
 }
 
 export enum ValueTypes {
-    AMR = 'amr',
-    SKETCH = 'sketch'
+    AMR = "amr",
+    SKETCH = "sketch"
 }
 
 export interface IsolateValue {
@@ -37,9 +37,9 @@ export interface IsolateValue {
 }
 
 export enum AnalysisType {
-    ASSIGN = 'assign',
-    MICROREACT = 'microreact',
-    NETWORK = 'network'
+    ASSIGN = "assign",
+    MICROREACT = "microreact",
+    NETWORK = "network"
 }
 
 export type AnalysisStatus = {
@@ -54,19 +54,19 @@ export interface BeebopError {
 }
 
 export interface ResponseFailure {
-    status: 'failure';
+    status: "failure";
     data: null;
     errors: BeebopError[];
 }
 
 export interface ResponseSuccess {
-    status: 'success';
+    status: "success";
     data: unknown;
     errors: null;
 }
 
 export enum Errors {
-    WRONG_TOKEN='Wrong Token',
+    WRONG_TOKEN="Wrong Token",
 }
 
 interface GraphmlExtension {

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -1,110 +1,110 @@
 export function addRowspan(tableSorted: Record<string, string | number>[]) {
-  // extract cluster numbers
-  const clusters = tableSorted.map((a) => a.Cluster);
-  // get counts of individual clusters
-  const counts = {} as Record<number | string, number>;
-  clusters.forEach((num) => {
-    counts[num] = counts[num] ? counts[num] + 1 : 1;
-  });
-  // generate list of rowspans to be added to table
-  const rowspan = [] as number[];
-  Object.values(counts).forEach((num) => {
-    if (num === 1) {
-      rowspan.push(1);
-    } else {
-      rowspan.push(num);
-      for (let i = 0; i < (num - 1); i += 1) {
-        rowspan.push(0);
-      }
-    }
-  });
-  // map rowspans to hashes
-  const hashes = tableSorted.map((a) => a.Hash);
-  const rowspanMap = {} as Record<string, number>;
-  hashes.forEach((hash, i) => {
-    rowspanMap[hash] = rowspan[i];
-  });
-  // add rowspans to table
-  const tableRowspan = tableSorted.map((obj) => ({ ...obj, Rowspan: rowspanMap[obj.Hash] }));
-  return tableRowspan;
+    // extract cluster numbers
+    const clusters = tableSorted.map((a) => a.Cluster);
+    // get counts of individual clusters
+    const counts = {} as Record<number | string, number>;
+    clusters.forEach((num) => {
+        counts[num] = counts[num] ? counts[num] + 1 : 1;
+    });
+    // generate list of rowspans to be added to table
+    const rowspan = [] as number[];
+    Object.values(counts).forEach((num) => {
+        if (num === 1) {
+            rowspan.push(1);
+        } else {
+            rowspan.push(num);
+            for (let i = 0; i < (num - 1); i += 1) {
+                rowspan.push(0);
+            }
+        }
+    });
+    // map rowspans to hashes
+    const hashes = tableSorted.map((a) => a.Hash);
+    const rowspanMap = {} as Record<string, number>;
+    hashes.forEach((hash, i) => {
+        rowspanMap[hash] = rowspan[i];
+    });
+    // add rowspans to table
+    const tableRowspan = tableSorted.map((obj) => ({ ...obj, Rowspan: rowspanMap[obj.Hash] }));
+    return tableRowspan;
 }
 
 export function getRGB(value: string | number, antibiotic: string) {
-  // Translate probabilities into colours, depending on antibiotic
-  if (value === 'processing') {
-    return 'rgb(50, 168, 82)';
-  }
-  let prob = 0;
-  if (antibiotic === 'Penicillin' || antibiotic === 'Cotrim') {
+    // Translate probabilities into colours, depending on antibiotic
+    if (value === "processing") {
+        return "rgb(50, 168, 82)";
+    }
+    let prob = 0;
+    if (antibiotic === "Penicillin" || antibiotic === "Cotrim") {
     // achieve more colourchanges towards the extremes 0&1
-    prob = 0.07 * Math.log((Number(value) + 0.0008) / (1 - 0.9992 * Number(value))) + 0.499944067;
-  } else if (antibiotic === 'Chloramphenicol' || antibiotic === 'Tetracycline') {
+        prob = 0.07 * Math.log((Number(value) + 0.0008) / (1 - 0.9992 * Number(value))) + 0.499944067;
+    } else if (antibiotic === "Chloramphenicol" || antibiotic === "Tetracycline") {
     // achieve more changes around .5
-    prob = (Math.exp(40 * Number(value) - 20)) / (1 + Math.exp(40 * Number(value) - 20));
-  } else if (antibiotic === 'Erythromycin') {
-    prob = Number(value);
-  }
-  // set targeted colours for values 0 and 1
-  const target0 = { r: 196, g: 212, b: 245 };
-  const target1 = { r: 2, g: 57, b: 168 };
-  const r = Math.round(target0.r - (prob * (target0.r - target1.r)));
-  const g = Math.round(target0.g - (prob * (target0.g - target1.g)));
-  const b = Math.round(target0.b - (prob * (target0.b - target1.b)));
-  return ['rgb(', r, ',', g, ',', b, ')'].join('');
+        prob = (Math.exp(40 * Number(value) - 20)) / (1 + Math.exp(40 * Number(value) - 20));
+    } else if (antibiotic === "Erythromycin") {
+        prob = Number(value);
+    }
+    // set targeted colours for values 0 and 1
+    const target0 = { r: 196, g: 212, b: 245 };
+    const target1 = { r: 2, g: 57, b: 168 };
+    const r = Math.round(target0.r - (prob * (target0.r - target1.r)));
+    const g = Math.round(target0.g - (prob * (target0.g - target1.g)));
+    const b = Math.round(target0.b - (prob * (target0.b - target1.b)));
+    return ["rgb(", r, ",", g, ",", b, ")"].join("");
 }
 export function verbalProb(prob: number, antibiotic: string) {
-  // Translate probabilities into words, depending on antibiotic
-  let word = prob.toString();
-  if (antibiotic === 'Penicillin') {
-    if (prob >= 0.9) {
-      word = 'Highly likely';
-    } else if (prob >= 0.75) {
-      word = 'Very good chance';
-    } else if (prob >= 0.5) {
-      word = 'Probably';
-    } else if (prob >= 0.4) {
-      word = 'Probably not';
-    } else if (prob >= 0.2) {
-      word = 'Unlikely';
-    } else if (prob < 0.2) { word = 'Highly unlikely'; }
-  } else if (antibiotic === 'Chloramphenicol') {
-    if (prob >= 0.55) {
-      word = 'Probably';
-    } else if (prob >= 0.5) {
-      word = 'Unsure';
-    } else if (prob < 0.5) {
-      word = 'Highly unlikely';
+    // Translate probabilities into words, depending on antibiotic
+    let word = prob.toString();
+    if (antibiotic === "Penicillin") {
+        if (prob >= 0.9) {
+            word = "Highly likely";
+        } else if (prob >= 0.75) {
+            word = "Very good chance";
+        } else if (prob >= 0.5) {
+            word = "Probably";
+        } else if (prob >= 0.4) {
+            word = "Probably not";
+        } else if (prob >= 0.2) {
+            word = "Unlikely";
+        } else if (prob < 0.2) { word = "Highly unlikely"; }
+    } else if (antibiotic === "Chloramphenicol") {
+        if (prob >= 0.55) {
+            word = "Probably";
+        } else if (prob >= 0.5) {
+            word = "Unsure";
+        } else if (prob < 0.5) {
+            word = "Highly unlikely";
+        }
+    } else if (antibiotic === "Erythromycin") {
+        if (prob >= 0.5) {
+            word = "Almost certainly";
+        } else if (prob >= 0.2) {
+            word = "Probably not";
+        } else if (prob < 0.2) {
+            word = "Highly unlikely";
+        }
+    } else if (antibiotic === "Tetracycline") {
+        if (prob >= 0.5) {
+            word = "Almost certainly";
+        } else if (prob < 0.5) {
+            word = "Highly unlikely";
+        }
+    } else if (antibiotic === "Cotrim") {
+        if (prob >= 0.8) {
+            word = "Almost certainly";
+        } else if (prob >= 0.7) {
+            word = "Highly likely";
+        } else if (prob >= 0.5) {
+            word = "Very good chance";
+        } else if (prob >= 0.2) {
+            word = "Probably not";
+        } else if (prob < 0.2) {
+            word = "Unlikely";
+        }
     }
-  } else if (antibiotic === 'Erythromycin') {
-    if (prob >= 0.5) {
-      word = 'Almost certainly';
-    } else if (prob >= 0.2) {
-      word = 'Probably not';
-    } else if (prob < 0.2) {
-      word = 'Highly unlikely';
-    }
-  } else if (antibiotic === 'Tetracycline') {
-    if (prob >= 0.5) {
-      word = 'Almost certainly';
-    } else if (prob < 0.5) {
-      word = 'Highly unlikely';
-    }
-  } else if (antibiotic === 'Cotrim') {
-    if (prob >= 0.8) {
-      word = 'Almost certainly';
-    } else if (prob >= 0.7) {
-      word = 'Highly likely';
-    } else if (prob >= 0.5) {
-      word = 'Very good chance';
-    } else if (prob >= 0.2) {
-      word = 'Probably not';
-    } else if (prob < 0.2) {
-      word = 'Unlikely';
-    }
-  }
-  return word;
+    return word;
 }
 
 export function tooltipLine(name: string, num: number) {
-  return `${name}: ${verbalProb(num, name)} <small>(${num})</small>`;
+    return `${name}: ${verbalProb(num, name)} <small>(${num})</small>`;
 }

--- a/app/client/src/views/AboutView.vue
+++ b/app/client/src/views/AboutView.vue
@@ -6,13 +6,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import VersionInfo from '@/components/VersionInfo.vue';
+import { defineComponent } from "vue";
+import VersionInfo from "@/components/VersionInfo.vue";
 
 export default defineComponent({
-  name: 'AboutView',
-  components: {
-    VersionInfo,
-  },
+    name: "AboutView",
+    components: {
+        VersionInfo
+    }
 });
 </script>

--- a/app/client/src/views/HomeView.vue
+++ b/app/client/src/views/HomeView.vue
@@ -9,25 +9,25 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapState, mapActions } from 'vuex';
-import LoginPrompt from '@/components/LoginPrompt.vue';
-import SelectAction from '@/components/SelectAction.vue';
+import { defineComponent } from "vue";
+import { mapState, mapActions } from "vuex";
+import LoginPrompt from "@/components/LoginPrompt.vue";
+import SelectAction from "@/components/SelectAction.vue";
 
 export default defineComponent({
-  name: 'HomeView',
-  components: {
-    LoginPrompt,
-    SelectAction,
-  },
-  mounted() {
-    this.getUser();
-  },
-  methods: {
-    ...mapActions(['getUser']),
-  },
-  computed: {
-    ...mapState(['user']),
-  },
+    name: "HomeView",
+    components: {
+        LoginPrompt,
+        SelectAction
+    },
+    mounted() {
+        this.getUser();
+    },
+    methods: {
+        ...mapActions(["getUser"])
+    },
+    computed: {
+        ...mapState(["user"])
+    }
 });
 </script>

--- a/app/client/src/views/ProjectView.vue
+++ b/app/client/src/views/ProjectView.vue
@@ -54,45 +54,45 @@
 </template>
 
 <script lang='ts'>
-import { defineComponent } from 'vue';
-import { mapState, mapActions, mapGetters } from 'vuex';
-import DropZone from '@/components/DropZone.vue';
-import StartButton from '@/components/StartButton.vue';
-import ProgressBar from '@/components/ProgressBar.vue';
-import ResultsTable from '@/components/ResultsTable.vue';
-import NetworkVisualisations from '@/components/NetworkVisualisations.vue';
+import { defineComponent } from "vue";
+import { mapState, mapActions, mapGetters } from "vuex";
+import DropZone from "@/components/DropZone.vue";
+import StartButton from "@/components/StartButton.vue";
+import ProgressBar from "@/components/ProgressBar.vue";
+import ResultsTable from "@/components/ResultsTable.vue";
+import NetworkVisualisations from "@/components/NetworkVisualisations.vue";
 
 export default defineComponent({
-  name: 'ProjectView',
-  components: {
-    DropZone,
-    StartButton,
-    ProgressBar,
-    ResultsTable,
-    NetworkVisualisations,
-  },
-  data() {
-    return {
-      selectedTab: 'table',
-    };
-  },
-  mounted() {
-    // redirect to home page if no project name
-    if (!this.projectName) {
-      this.$router.push('/');
-    } else {
-      this.getUser();
-    }
-  },
-  methods: {
-    ...mapActions(['getUser']),
-    onInput(value: string) {
-      this.selectedTab = value;
+    name: "ProjectView",
+    components: {
+        DropZone,
+        StartButton,
+        ProgressBar,
+        ResultsTable,
+        NetworkVisualisations
     },
-  },
-  computed: {
-    ...mapState(['user', 'submitStatus', 'analysisStatus', 'projectName']),
-    ...mapGetters(['uniqueClusters']),
-  },
+    data() {
+        return {
+            selectedTab: "table"
+        };
+    },
+    mounted() {
+    // redirect to home page if no project name
+        if (!this.projectName) {
+            this.$router.push("/");
+        } else {
+            this.getUser();
+        }
+    },
+    methods: {
+        ...mapActions(["getUser"]),
+        onInput(value: string) {
+            this.selectedTab = value;
+        }
+    },
+    computed: {
+        ...mapState(["user", "submitStatus", "analysisStatus", "projectName"]),
+        ...mapGetters(["uniqueClusters"])
+    }
 });
 </script>

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -34,7 +34,7 @@ test.describe("Logged in Tests", () => {
         await expect(await page.locator("button#create-project-btn")).toBeVisible();
     });
 
-    test("should update file list when files are dropped, process them in WebWorker and submit on click to backend", async ({ page }) => {
+    test("should update file list on drop, process them in WebWorker and submit on click", async ({ page }) => {
         await page.fill("input#create-project-name", "test project");
         await page.click("button#create-project-btn");
         // Read files into a buffer
@@ -74,8 +74,10 @@ test.describe("Logged in Tests", () => {
         await page.waitForTimeout(20000);
         await expect(page.locator(".progress-bar")).toContainText("100.00%");
         // Expect clusters appearing in table
-        await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(["6930_8_13.fa", "✔", "PCETE SXT", "7"]);
-        await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(["6930_8_11.fa", "✔", "PCETE SXT", "24"]);
+        await expect(page.locator('tr:has-text("6930_8_13.fa")'))
+            .toContainText(["6930_8_13.fa", "✔", "PCETE SXT", "7"]);
+        await expect(page.locator('tr:has-text("6930_8_11.fa")'))
+            .toContainText(["6930_8_11.fa", "✔", "PCETE SXT", "24"]);
         // Expect download buttons and button to generate microreact URL to appear
         await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText("Download zip file");
         await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText("Generate Microreact URL");
@@ -88,7 +90,8 @@ test.describe("Logged in Tests", () => {
         await page.locator("input").fill(process.env.MICROREACT_TOKEN as string);
         await page.click("text=Save token");
         await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText("Visit Microreact URL");
-        await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toHaveAttribute("href", /https:\/\/microreact.org\/project\/.*-poppunk.*/);
+        await expect(page.locator('tr:has-text("6930_8_13.fa") a'))
+            .toHaveAttribute("href", /https:\/\/microreact.org\/project\/.*-poppunk.*/);
         // nework visualisation component has 1 button for each cluster (=2) and renders canvases
         await page.click(".nav-link >> text=Network");
         await expect(page.locator("#cluster-tabs")).toHaveCount(2);

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -1,98 +1,98 @@
 /// <reference lib="dom"/>
 /* eslint-disable no-tabs */
 
-import { test, expect } from '@playwright/test';
-import { readFileSync } from 'fs';
-import config from '../../src/settings/development/config';
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
+import config from "../../src/settings/development/config";
 
-test.describe('Logged in Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(`${config.serverUrl()}/login/mock`);
-    await page.goto(config.clientUrl());
-  });
+test.describe("Logged in Tests", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(`${config.serverUrl()}/login/mock`);
+        await page.goto(config.clientUrl());
+    });
 
-  test('should display Logout in dropdown menu', async ({ page }) => {
-    await page.click('.bi-three-dots-vertical');
-    await expect(page.locator('.dropdown-menu')).toContainText('Logout');
-  });
+    test("should display Logout in dropdown menu", async ({ page }) => {
+        await page.click(".bi-three-dots-vertical");
+        await expect(page.locator(".dropdown-menu")).toContainText("Logout");
+    });
 
-  test('should display Login buttons after Logging out', async ({ page }) => {
-    await page.click('.bi-three-dots-vertical');
-    await page.click('text=Logout');
-    await expect(page.locator('.auth')).toContainText('Login');
-  });
+    test("should display Login buttons after Logging out", async ({ page }) => {
+        await page.click(".bi-three-dots-vertical");
+        await page.click("text=Logout");
+        await expect(page.locator(".auth")).toContainText("Login");
+    });
 
-  test('should display dropzone in Project view', async ({ page }) => {
-    await page.fill('input#create-project-name', 'test project');
-    await page.click('button#create-project-btn');
-    await expect(page.locator('.dropzone')).toBeVisible();
-    await expect(page.locator('h2')).toContainText('Project: test project');
-  });
+    test("should display dropzone in Project view", async ({ page }) => {
+        await page.fill("input#create-project-name", "test project");
+        await page.click("button#create-project-btn");
+        await expect(page.locator(".dropzone")).toBeVisible();
+        await expect(page.locator("h2")).toContainText("Project: test project");
+    });
 
-  test('should redirect from project page to home page if name has not been provided', async ({page}) => {
-    await page.goto(`${config.clientUrl()}/project`);
-    await expect(await page.locator('button#create-project-btn')).toBeVisible();
-  });
+    test("should redirect from project page to home page if name has not been provided", async ({ page }) => {
+        await page.goto(`${config.clientUrl()}/project`);
+        await expect(await page.locator("button#create-project-btn")).toBeVisible();
+    });
 
-  test('should update file list when files are dropped, process them in WebWorker and submit on click to backend', async ({ page }) => {
-    await page.fill('input#create-project-name', 'test project');
-    await page.click('button#create-project-btn');
-    // Read files into a buffer
-    const buffer = readFileSync('./tests/files/6930_8_13.fa', { encoding: 'utf8', flag: 'r' });
-    const buffer2 = readFileSync('./tests/files/6930_8_11.fa', { encoding: 'utf8', flag: 'r' });
-    // Create the DataTransfer and add Files
-    const dataTransfer = await page.evaluateHandle(
-      ({ data, data2 }) => {
-        const dt = new DataTransfer();
-        const file = new File([data.toString()], '6930_8_13.fa', { type: 'text/plain' });
-        const file2 = new File([data2.toString()], '6930_8_11.fa', { type: 'text/plain' });
-        dt.items.add(file);
-        dt.items.add(file2);
-        return dt;
-      },
-      {
-        data: buffer,
-        data2: buffer2,
-      },
-    );
-    // Dropping files to dropzone
-    await page.dispatchEvent('.dropzone', 'drop', { dataTransfer });
-    // Expect count of files to be 2
-    await expect(page.locator('.count')).toContainText('2');
-    // Expect table to appear
-    await expect(page.locator('table')).toHaveCount(1);
-    // Expect files, hashes, AMR and Sketch appearing in table
-    await page.waitForTimeout(10000);
-    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT']);
-    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT']);
-    // expect to have a 'start analysis' button
-    await expect(page.locator('.start-analysis')).toContainText('Start Analysis');
-    // Expect to see ProgressBar once button was pressed
-    await page.click('text=Start Analysis');
-    await expect(page.locator('.progress-bar')).toHaveCount(1);
-    // Expect all jobs to finish
-    await page.waitForTimeout(20000);
-    await expect(page.locator('.progress-bar')).toContainText('100.00%');
-    // Expect clusters appearing in table
-    await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(['6930_8_13.fa', '✔', 'PCETE SXT', '7']);
-    await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(['6930_8_11.fa', '✔', 'PCETE SXT', '24']);
-    // Expect download buttons and button to generate microreact URL to appear
-    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText('Download zip file');
-    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText('Generate Microreact URL');
-    await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText('Download zip file');
-    // on clicking Generate Microreact URL button, modal appears
-    await page.click('text=Generate Microreact URL');
-    await expect(page.locator('.modalFlex')).toContainText('No token submitted yet');
-    await expect(page.locator('.modalFlex .btn')).toContainText('Save token');
-    // after submitting microreact token, button turns into link to microreact.org
-    await page.locator('input').fill(process.env.MICROREACT_TOKEN as string);
-    await page.click('text=Save token');
-    await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText('Visit Microreact URL');
-    await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toHaveAttribute('href', /https:\/\/microreact.org\/project\/.*-poppunk.*/);
-    // nework visualisation component has 1 button for each cluster (=2) and renders canvases
-    await page.click('.nav-link >> text=Network');
-    await expect(page.locator('#cluster-tabs')).toHaveCount(2);
-    await expect(page.locator('#cy')).toHaveCount(1);
-    await expect(page.locator('#cy canvas')).toHaveCount(3);
-  });
+    test("should update file list when files are dropped, process them in WebWorker and submit on click to backend", async ({ page }) => {
+        await page.fill("input#create-project-name", "test project");
+        await page.click("button#create-project-btn");
+        // Read files into a buffer
+        const buffer = readFileSync("./tests/files/6930_8_13.fa", { encoding: "utf8", flag: "r" });
+        const buffer2 = readFileSync("./tests/files/6930_8_11.fa", { encoding: "utf8", flag: "r" });
+        // Create the DataTransfer and add Files
+        const dataTransfer = await page.evaluateHandle(
+            ({ data, data2 }) => {
+                const dt = new DataTransfer();
+                const file = new File([data.toString()], "6930_8_13.fa", { type: "text/plain" });
+                const file2 = new File([data2.toString()], "6930_8_11.fa", { type: "text/plain" });
+                dt.items.add(file);
+                dt.items.add(file2);
+                return dt;
+            },
+            {
+                data: buffer,
+                data2: buffer2
+            }
+        );
+        // Dropping files to dropzone
+        await page.dispatchEvent(".dropzone", "drop", { dataTransfer });
+        // Expect count of files to be 2
+        await expect(page.locator(".count")).toContainText("2");
+        // Expect table to appear
+        await expect(page.locator("table")).toHaveCount(1);
+        // Expect files, hashes, AMR and Sketch appearing in table
+        await page.waitForTimeout(10000);
+        await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(["6930_8_13.fa", "✔", "PCETE SXT"]);
+        await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(["6930_8_11.fa", "✔", "PCETE SXT"]);
+        // expect to have a 'start analysis' button
+        await expect(page.locator(".start-analysis")).toContainText("Start Analysis");
+        // Expect to see ProgressBar once button was pressed
+        await page.click("text=Start Analysis");
+        await expect(page.locator(".progress-bar")).toHaveCount(1);
+        // Expect all jobs to finish
+        await page.waitForTimeout(20000);
+        await expect(page.locator(".progress-bar")).toContainText("100.00%");
+        // Expect clusters appearing in table
+        await expect(page.locator('tr:has-text("6930_8_13.fa")')).toContainText(["6930_8_13.fa", "✔", "PCETE SXT", "7"]);
+        await expect(page.locator('tr:has-text("6930_8_11.fa")')).toContainText(["6930_8_11.fa", "✔", "PCETE SXT", "24"]);
+        // Expect download buttons and button to generate microreact URL to appear
+        await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(0)).toContainText("Download zip file");
+        await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(1)).toContainText("Generate Microreact URL");
+        await expect(page.locator('tr:has-text("6930_8_13.fa") .btn').nth(2)).toContainText("Download zip file");
+        // on clicking Generate Microreact URL button, modal appears
+        await page.click("text=Generate Microreact URL");
+        await expect(page.locator(".modalFlex")).toContainText("No token submitted yet");
+        await expect(page.locator(".modalFlex .btn")).toContainText("Save token");
+        // after submitting microreact token, button turns into link to microreact.org
+        await page.locator("input").fill(process.env.MICROREACT_TOKEN as string);
+        await page.click("text=Save token");
+        await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText("Visit Microreact URL");
+        await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toHaveAttribute("href", /https:\/\/microreact.org\/project\/.*-poppunk.*/);
+        // nework visualisation component has 1 button for each cluster (=2) and renders canvases
+        await page.click(".nav-link >> text=Network");
+        await expect(page.locator("#cluster-tabs")).toHaveCount(2);
+        await expect(page.locator("#cy")).toHaveCount(1);
+        await expect(page.locator("#cy canvas")).toHaveCount(3);
+    });
 });

--- a/app/client/tests/e2e/LoggedOut.spec.ts
+++ b/app/client/tests/e2e/LoggedOut.spec.ts
@@ -1,22 +1,22 @@
-import { test, expect } from '@playwright/test';
-import config from '../../src/settings/development/config';
+import { test, expect } from "@playwright/test";
+import config from "../../src/settings/development/config";
 
-test.describe('Logged out Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(config.clientUrl());
-  });
+test.describe("Logged out Tests", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(config.clientUrl());
+    });
 
-  test('should display greeting on start page', async ({ page }) => {
-    await expect(page.locator('.home')).toContainText('Welcome to beebop!');
-  });
+    test("should display greeting on start page", async ({ page }) => {
+        await expect(page.locator(".home")).toContainText("Welcome to beebop!");
+    });
 
-  test('should display version info when clicking on about', async ({ page }) => {
-    await page.click('.bi-three-dots-vertical');
-    await page.click('text=About');
-    await expect(page.locator('.about:has(.version-info)')).toContainText(['beebop']);
-  });
+    test("should display version info when clicking on about", async ({ page }) => {
+        await page.click(".bi-three-dots-vertical");
+        await page.click("text=About");
+        await expect(page.locator(".about:has(.version-info)")).toContainText(["beebop"]);
+    });
 
-  test('should display Login button', async ({ page }) => {
-    await expect(page.locator('.auth')).toContainText('Login');
-  });
+    test("should display Login button", async ({ page }) => {
+        await expect(page.locator(".auth")).toContainText("Login");
+    });
 });

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -1,43 +1,43 @@
-import { RootState } from '@/store/state';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
+import { RootState } from "@/store/state";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import {
-  ResponseFailure, ResponseSuccess, BeebopError,
-} from '../src/types';
+    ResponseFailure, ResponseSuccess, BeebopError
+} from "../src/types";
 
 export const mockAxios = new MockAdapter(axios);
 
 export function mockRootState(state: Partial<RootState> = {}): RootState {
-  return {
-    errors: [],
-    versions: [],
-    user: null,
-    microreactToken: null,
-    results: {
-      perIsolate: {},
-      perCluster: {},
-    },
-    submitStatus: null,
-    analysisStatus: {
-      assign: null, microreact: null, network: null,
-    },
-    statusInterval: undefined,
-    projectHash: null,
-    projectName: null,
-    ...state,
-  };
+    return {
+        errors: [],
+        versions: [],
+        user: null,
+        microreactToken: null,
+        results: {
+            perIsolate: {},
+            perCluster: {}
+        },
+        submitStatus: null,
+        analysisStatus: {
+            assign: null, microreact: null, network: null
+        },
+        statusInterval: undefined,
+        projectHash: null,
+        projectName: null,
+        ...state
+    };
 }
 
 export const mockSuccess = (data: any): ResponseSuccess => ({
-  data,
-  status: 'success',
-  errors: null,
+    data,
+    status: "success",
+    errors: null
 });
 
-export const mockError = (errorMessage = 'some message'): BeebopError => ({ error: 'OTHER_ERROR', detail: errorMessage });
+export const mockError = (errorMessage = "some message"): BeebopError => ({ error: "OTHER_ERROR", detail: errorMessage });
 
 export const mockFailure = (errorMessage: string): ResponseFailure => ({
-  data: null,
-  status: 'failure',
-  errors: [mockError(errorMessage)],
+    data: null,
+    status: "failure",
+    errors: [mockError(errorMessage)]
 });

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -34,7 +34,7 @@ export const mockSuccess = (data: any): ResponseSuccess => ({
     errors: null
 });
 
-export const mockError = (errorMessage = "some message"): BeebopError => ({ error: "OTHER_ERROR", detail: errorMessage });
+export const mockError = (message = "some message"): BeebopError => ({ error: "OTHER_ERROR", detail: message });
 
 export const mockFailure = (errorMessage: string): ResponseFailure => ({
     data: null,

--- a/app/client/tests/unit/App.spec.ts
+++ b/app/client/tests/unit/App.spec.ts
@@ -1,41 +1,41 @@
-import App from '@/App.vue';
-import { shallowMount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import NavbarDropdown from '@/components/NavbarDropdown.vue';
-import { mockRootState } from '../mocks';
+import App from "@/App.vue";
+import { shallowMount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import NavbarDropdown from "@/components/NavbarDropdown.vue";
+import { mockRootState } from "../mocks";
 
-describe('App', () => {
-  const getUser = jest.fn();
+describe("App", () => {
+    const getUser = jest.fn();
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-    }),
-    actions: {
-      getUser,
-    },
-  });
-  const wrapper = shallowMount(App, {
-    global: {
-      plugins: [store],
-    },
-  });
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            }
+        }),
+        actions: {
+            getUser
+        }
+    });
+    const wrapper = shallowMount(App, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('gets user information on mount', () => {
-    expect(getUser).toHaveBeenCalledTimes(1);
-  });
+    test("gets user information on mount", () => {
+        expect(getUser).toHaveBeenCalledTimes(1);
+    });
 
-  test('displays logo and has Navbar dropdown menu', () => {
-    expect(wrapper.findAll('.logo').length).toBe(1);
-    expect(wrapper.findAllComponents(NavbarDropdown).length).toBe(1);
-  });
+    test("displays logo and has Navbar dropdown menu", () => {
+        expect(wrapper.findAll(".logo").length).toBe(1);
+        expect(wrapper.findAllComponents(NavbarDropdown).length).toBe(1);
+    });
 });

--- a/app/client/tests/unit/apiService.spec.ts
+++ b/app/client/tests/unit/apiService.spec.ts
@@ -1,394 +1,394 @@
 /* eslint-disable no-console */
-import { api } from '../../src/apiService';
+import { api } from "../../src/apiService";
 import {
-  mockAxios, mockError, mockFailure, mockSuccess, mockRootState,
-} from '../mocks';
+    mockAxios, mockError, mockFailure, mockSuccess, mockRootState
+} from "../mocks";
 import Mock = jest.Mock;
 
 const rootState = mockRootState();
 
-describe('ApiService', () => {
-  const TEST_ROUTE = '/test';
-  const TEST_BODY = 'test body';
+describe("ApiService", () => {
+    const TEST_ROUTE = "/test";
+    const TEST_BODY = "test body";
 
-  beforeEach(() => {
-    console.log = jest.fn();
-    console.warn = jest.fn();
-    mockAxios.reset();
-  });
-
-  afterEach(() => {
-    (console.log as jest.Mock).mockClear();
-    (console.warn as jest.Mock).mockClear();
-    jest.clearAllMocks();
-  });
-
-  const expectNoErrorHandlerMsgLogged = () => {
-    expect((console.warn as jest.Mock).mock.calls[0][0])
-      .toBe(`No error handler registered for request ${TEST_ROUTE}.`);
-  };
-
-  const expectCommitsErrorMessage = (commit: Mock, errorMessage: string) => {
-    expect(commit.mock.calls.length).toBe(1);
-    expect(commit.mock.calls[0][0]).toStrictEqual({
-      type: 'addError',
-      payload: mockError(errorMessage),
+    beforeEach(() => {
+        console.log = jest.fn();
+        console.warn = jest.fn();
+        mockAxios.reset();
     });
-  };
 
-  const expectCommitsDefaultErrorMessage = (commit: Mock) => {
-    expect(commit.mock.calls.length).toBe(1);
-    expect(commit.mock.calls[0][0]).toStrictEqual({
-      type: 'addError',
-      payload: {
-        error: 'MALFORMED_RESPONSE',
-        detail: 'API response failed but did not contain any error information. Please contact support.',
-      },
+    afterEach(() => {
+        (console.log as jest.Mock).mockClear();
+        (console.warn as jest.Mock).mockClear();
+        jest.clearAllMocks();
     });
-  };
 
-  it('console logs error on get', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailure('some error message'));
-
-    await api({ commit: jest.fn(), rootState } as any)
-      .get(TEST_ROUTE);
-
-    expectNoErrorHandlerMsgLogged();
-
-    expect((console.log as jest.Mock).mock.calls[0][0].errors[0].detail)
-      .toBe('some error message');
-  });
-
-  it('console logs error on post', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, mockFailure('some error message'));
-
-    await api({ commit: jest.fn(), rootState } as any)
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expectNoErrorHandlerMsgLogged();
-
-    expect((console.log as jest.Mock).mock.calls[0][0].errors[0].detail)
-      .toBe('some error message');
-  });
-
-  it('commits the the first error message to errors module by default on get', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailure('some error message'));
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .get(TEST_ROUTE);
-
-    expectNoErrorHandlerMsgLogged();
-    expectCommitsErrorMessage(commit, 'some error message');
-  });
-
-  it('commits the the first error message to errors module by default on post', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, mockFailure('some error message'));
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expectNoErrorHandlerMsgLogged();
-    expectCommitsErrorMessage(commit, 'some error message');
-  });
-
-  it('if no first error message, commits a default error message to errors module by default on get', async () => {
-    const failure = {
-      data: {},
-      status: 'failure',
-      errors: [],
-    };
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, failure);
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .get(TEST_ROUTE);
-
-    expectNoErrorHandlerMsgLogged();
-    expectCommitsDefaultErrorMessage(commit);
-  });
-
-  it('if no first error message, commits a default error message to errors module by default on post', async () => {
-    const failure = {
-      data: {},
-      status: 'failure',
-      errors: [],
-    };
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, failure);
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expectNoErrorHandlerMsgLogged();
-    expectCommitsDefaultErrorMessage(commit);
-  });
-
-  it('commits the first error with the specified type if well formatted on get', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailure('some error message'));
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toStrictEqual({ error: 'OTHER_ERROR', detail: 'some error message' });
-  });
-
-  it('commits the first error with the specified type if well formatted on post', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, mockFailure('some error message'));
-
-    const commit = jest.fn();
-
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toStrictEqual({ error: 'OTHER_ERROR', detail: 'some error message' });
-  });
-
-  it('commits the error type if the error detail is missing on get', async () => {
-    const mockFailureNoDetail = {
-      data: null,
-      status: 'failure',
-      errors: [{ error: 'OTHER_ERROR' }],
+    const expectNoErrorHandlerMsgLogged = () => {
+        expect((console.warn as jest.Mock).mock.calls[0][0])
+            .toBe(`No error handler registered for request ${TEST_ROUTE}.`);
     };
 
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailureNoDetail);
-
-    console.log(mockFailure(null as any));
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toStrictEqual({ error: 'OTHER_ERROR' });
-  });
-
-  it('commits the error type if the error detail is missing on post', async () => {
-    const mockFailureNoDetail = {
-      data: null,
-      status: 'failure',
-      errors: [{ error: 'OTHER_ERROR' }],
+    const expectCommitsErrorMessage = (commit: Mock, errorMessage: string) => {
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "addError",
+            payload: mockError(errorMessage)
+        });
     };
 
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, mockFailureNoDetail);
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toStrictEqual({ error: 'OTHER_ERROR' });
-  });
-
-  it('resets microreact Token if receiving "Wrong Token" Error', async () => {
-    const mockFailureNoDetail = {
-      data: null,
-      status: 'failure',
-      errors: [{ error: 'Wrong Token' }],
+    const expectCommitsDefaultErrorMessage = (commit: Mock) => {
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "addError",
+            payload: {
+                error: "MALFORMED_RESPONSE",
+                detail: "API response failed but did not contain any error information. Please contact support."
+            }
+        });
     };
 
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(500, mockFailureNoDetail);
+    it("console logs error on get", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailure("some error message"));
 
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
+        await api({ commit: jest.fn(), rootState } as any)
+            .get(TEST_ROUTE);
 
-    expect(commit.mock.calls[0][0]).toBe('setToken');
-    expect(commit.mock.calls[0][1]).toStrictEqual(null);
-    expect(commit.mock.calls[1][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[1][1]).toStrictEqual({ error: 'Wrong Token' });
-  });
+        expectNoErrorHandlerMsgLogged();
 
-  it('commits the success response with the specified type on get', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(200, mockSuccess('test data'));
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toBe('test data');
-  });
-
-  it('commits the success response with the specified type on post', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(200, mockSuccess('test data'));
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toBe('test data');
-  });
-
-  it('commits the success response with the specified type with root true', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(200, mockSuccess('test data'));
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1]).toBe('test data');
-  });
-
-  it('commits the error response with the specified type with root true', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailure('TEST ERROR'));
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withError('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls[0][0]).toBe('TEST_TYPE');
-    expect(commit.mock.calls[0][1].detail).toBe('TEST ERROR');
-  });
-
-  it('get returns the response object', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(200, mockSuccess('TEST'));
-
-    const commit = jest.fn();
-    const response = await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .get(TEST_ROUTE);
-
-    expect(response).toStrictEqual({ data: 'TEST', errors: null, status: 'success' });
-  });
-
-  it('post returns the response object', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(200, mockSuccess('TEST'));
-
-    const commit = jest.fn();
-    const response = await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
-
-    expect(response).toStrictEqual({ data: 'TEST', errors: null, status: 'success' });
-  });
-
-  it('post sets Content-Type header', async () => {
-    mockAxios.onPost(TEST_ROUTE, TEST_BODY)
-      .reply(200, mockSuccess('TEST'));
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withSuccess('TEST_TYPE')
-      .post(TEST_ROUTE, TEST_BODY);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(mockAxios.history.post[0].headers!['Content-Type']).toBe('application/json');
-  });
-
-  async function expectCouldNotParseAPIResponseError() {
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls.length).toBe(1);
-    expect(commit.mock.calls[0][0]).toStrictEqual({
-      type: 'addError',
-      payload: {
-        error: 'MALFORMED_RESPONSE',
-        detail: 'Could not parse API response. Please contact support.',
-      },
+        expect((console.log as jest.Mock).mock.calls[0][0].errors[0].detail)
+            .toBe("some error message");
     });
-  }
 
-  it('commits parse error if API response is null', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500);
+    it("console logs error on post", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, mockFailure("some error message"));
 
-    await expectCouldNotParseAPIResponseError();
-  });
+        await api({ commit: jest.fn(), rootState } as any)
+            .post(TEST_ROUTE, TEST_BODY);
 
-  it('commits parse error if API response status is missing', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, { data: {}, errors: [] });
+        expectNoErrorHandlerMsgLogged();
 
-    await expectCouldNotParseAPIResponseError();
-  });
-
-  it('commits parse error if API response errors are missing', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, { data: {}, status: 'failure' });
-
-    await expectCouldNotParseAPIResponseError();
-  });
-
-  it('commits parse error if API response is valid BeebopResponse format', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, { data: {}, status: 'failure', errors: [{ error: 'error text', detail: 'detail text' }] });
-
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .get(TEST_ROUTE);
-
-    expect(commit.mock.calls.length).toBe(1);
-    expect(commit.mock.calls[0][0]).toStrictEqual({
-      type: 'addError',
-      payload: {
-        error: 'error text',
-        detail: 'detail text',
-      },
+        expect((console.log as jest.Mock).mock.calls[0][0].errors[0].detail)
+            .toBe("some error message");
     });
-  });
 
-  it('does nothing on error if ignoreErrors is true', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(500, mockFailure('some error message'));
+    it("commits the the first error message to errors module by default on get", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailure("some error message"));
 
-    const commit = jest.fn();
-    await api({ commit, rootState } as any)
-      .withSuccess('whatever')
-      .ignoreErrors()
-      .get(TEST_ROUTE);
+        const commit = jest.fn();
 
-    expect((console.warn as jest.Mock).mock.calls.length).toBe(0);
-    expect(commit.mock.calls.length).toBe(0);
-  });
+        await api({ commit, rootState } as any)
+            .get(TEST_ROUTE);
 
-  it('warns if error and success handlers are not set', async () => {
-    mockAxios.onGet(TEST_ROUTE)
-      .reply(200, mockSuccess(true));
+        expectNoErrorHandlerMsgLogged();
+        expectCommitsErrorMessage(commit, "some error message");
+    });
 
-    await api({ commit: jest.fn(), rootState } as any)
-      .get(TEST_ROUTE);
+    it("commits the the first error message to errors module by default on post", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, mockFailure("some error message"));
 
-    const warnings = (console.warn as jest.Mock).mock.calls;
+        const commit = jest.fn();
 
-    expectNoErrorHandlerMsgLogged();
-    expect(warnings[1][0]).toBe(`No success handler registered for request ${TEST_ROUTE}.`);
-  });
+        await api({ commit, rootState } as any)
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expectNoErrorHandlerMsgLogged();
+        expectCommitsErrorMessage(commit, "some error message");
+    });
+
+    it("if no first error message, commits a default error message to errors module by default on get", async () => {
+        const failure = {
+            data: {},
+            status: "failure",
+            errors: []
+        };
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, failure);
+
+        const commit = jest.fn();
+
+        await api({ commit, rootState } as any)
+            .get(TEST_ROUTE);
+
+        expectNoErrorHandlerMsgLogged();
+        expectCommitsDefaultErrorMessage(commit);
+    });
+
+    it("if no first error message, commits a default error message to errors module by default on post", async () => {
+        const failure = {
+            data: {},
+            status: "failure",
+            errors: []
+        };
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, failure);
+
+        const commit = jest.fn();
+
+        await api({ commit, rootState } as any)
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expectNoErrorHandlerMsgLogged();
+        expectCommitsDefaultErrorMessage(commit);
+    });
+
+    it("commits the first error with the specified type if well formatted on get", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailure("some error message"));
+
+        const commit = jest.fn();
+
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toStrictEqual({ error: "OTHER_ERROR", detail: "some error message" });
+    });
+
+    it("commits the first error with the specified type if well formatted on post", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, mockFailure("some error message"));
+
+        const commit = jest.fn();
+
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toStrictEqual({ error: "OTHER_ERROR", detail: "some error message" });
+    });
+
+    it("commits the error type if the error detail is missing on get", async () => {
+        const mockFailureNoDetail = {
+            data: null,
+            status: "failure",
+            errors: [{ error: "OTHER_ERROR" }]
+        };
+
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailureNoDetail);
+
+        console.log(mockFailure(null as any));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toStrictEqual({ error: "OTHER_ERROR" });
+    });
+
+    it("commits the error type if the error detail is missing on post", async () => {
+        const mockFailureNoDetail = {
+            data: null,
+            status: "failure",
+            errors: [{ error: "OTHER_ERROR" }]
+        };
+
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, mockFailureNoDetail);
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toStrictEqual({ error: "OTHER_ERROR" });
+    });
+
+    it('resets microreact Token if receiving "Wrong Token" Error', async () => {
+        const mockFailureNoDetail = {
+            data: null,
+            status: "failure",
+            errors: [{ error: "Wrong Token" }]
+        };
+
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(500, mockFailureNoDetail);
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expect(commit.mock.calls[0][0]).toBe("setToken");
+        expect(commit.mock.calls[0][1]).toStrictEqual(null);
+        expect(commit.mock.calls[1][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[1][1]).toStrictEqual({ error: "Wrong Token" });
+    });
+
+    it("commits the success response with the specified type on get", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(200, mockSuccess("test data"));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toBe("test data");
+    });
+
+    it("commits the success response with the specified type on post", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(200, mockSuccess("test data"));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toBe("test data");
+    });
+
+    it("commits the success response with the specified type with root true", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(200, mockSuccess("test data"));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1]).toBe("test data");
+    });
+
+    it("commits the error response with the specified type with root true", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailure("TEST ERROR"));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withError("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls[0][0]).toBe("TEST_TYPE");
+        expect(commit.mock.calls[0][1].detail).toBe("TEST ERROR");
+    });
+
+    it("get returns the response object", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(200, mockSuccess("TEST"));
+
+        const commit = jest.fn();
+        const response = await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .get(TEST_ROUTE);
+
+        expect(response).toStrictEqual({ data: "TEST", errors: null, status: "success" });
+    });
+
+    it("post returns the response object", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(200, mockSuccess("TEST"));
+
+        const commit = jest.fn();
+        const response = await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+
+        expect(response).toStrictEqual({ data: "TEST", errors: null, status: "success" });
+    });
+
+    it("post sets Content-Type header", async () => {
+        mockAxios.onPost(TEST_ROUTE, TEST_BODY)
+            .reply(200, mockSuccess("TEST"));
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withSuccess("TEST_TYPE")
+            .post(TEST_ROUTE, TEST_BODY);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(mockAxios.history.post[0].headers!["Content-Type"]).toBe("application/json");
+    });
+
+    async function expectCouldNotParseAPIResponseError() {
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "addError",
+            payload: {
+                error: "MALFORMED_RESPONSE",
+                detail: "Could not parse API response. Please contact support."
+            }
+        });
+    }
+
+    it("commits parse error if API response is null", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500);
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("commits parse error if API response status is missing", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, { data: {}, errors: [] });
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("commits parse error if API response errors are missing", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, { data: {}, status: "failure" });
+
+        await expectCouldNotParseAPIResponseError();
+    });
+
+    it("commits parse error if API response is valid BeebopResponse format", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, { data: {}, status: "failure", errors: [{ error: "error text", detail: "detail text" }] });
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .get(TEST_ROUTE);
+
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toStrictEqual({
+            type: "addError",
+            payload: {
+                error: "error text",
+                detail: "detail text"
+            }
+        });
+    });
+
+    it("does nothing on error if ignoreErrors is true", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(500, mockFailure("some error message"));
+
+        const commit = jest.fn();
+        await api({ commit, rootState } as any)
+            .withSuccess("whatever")
+            .ignoreErrors()
+            .get(TEST_ROUTE);
+
+        expect((console.warn as jest.Mock).mock.calls.length).toBe(0);
+        expect(commit.mock.calls.length).toBe(0);
+    });
+
+    it("warns if error and success handlers are not set", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(200, mockSuccess(true));
+
+        await api({ commit: jest.fn(), rootState } as any)
+            .get(TEST_ROUTE);
+
+        const warnings = (console.warn as jest.Mock).mock.calls;
+
+        expectNoErrorHandlerMsgLogged();
+        expect(warnings[1][0]).toBe(`No success handler registered for request ${TEST_ROUTE}.`);
+    });
 });

--- a/app/client/tests/unit/components/CytoscapeGraph.spec.ts
+++ b/app/client/tests/unit/components/CytoscapeGraph.spec.ts
@@ -4,134 +4,134 @@
 const mockReady = jest.fn();
 const mockGraphMl = jest.fn();
 const mockCytoscape = jest.fn().mockReturnValue({
-  ready: mockReady,
-  graphml: mockGraphMl,
+    ready: mockReady,
+    graphml: mockGraphMl
 });
 
-jest.mock('cytoscape', () => mockCytoscape);
+jest.mock("cytoscape", () => mockCytoscape);
 const mockCytoscapeGraphMlFunction = jest.fn();
 const mockCytoscapeGraphMl = jest.fn().mockReturnValue({
-  graphml: mockCytoscapeGraphMlFunction,
+    graphml: mockCytoscapeGraphMlFunction
 });
-jest.mock('cytoscape-graphml', () => mockCytoscapeGraphMl);
+jest.mock("cytoscape-graphml", () => mockCytoscapeGraphMl);
 
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex, { Store } from 'vuex';
-import CytoscapeGraph from '@/components/CytoscapeGraph.vue';
-import { mockRootState } from '../../mocks';
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex, { Store } from "vuex";
+import CytoscapeGraph from "@/components/CytoscapeGraph.vue";
+import { mockRootState } from "../../mocks";
 
-describe('CytoscapeGraph', () => {
-  const getGraphml = jest.fn();
+describe("CytoscapeGraph", () => {
+    const getGraphml = jest.fn();
 
-  const storeNoGraph = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {
-          2: {
-            cluster: '2',
-          },
-        },
-      },
-    }),
-    actions: {
-      getGraphml,
-    },
-  });
-
-  const storeWithGraph = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {
-          2: {
-            cluster: '2',
-            graph: '<graph></graph>',
-          },
-        },
-      },
-    }),
-    actions: {
-      getGraphml,
-    },
-  });
-
-  const getWrapper = (store: Store<RootState>) => mount(CytoscapeGraph, {
-    propsData: {
-      cluster: 2,
-    },
-    global: {
-      plugins: [store],
-    },
-  } as any);
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test('does a wrapper exist', () => {
-    const wrapper = getWrapper(storeNoGraph);
-    expect(wrapper.exists()).toBe(true);
-  });
-
-  test('getGraph() is called when no graph available', () => {
-    getWrapper(storeNoGraph);
-    expect(getGraphml).toHaveBeenCalledTimes(1);
-  });
-
-  test('cytoscape methods called as expected', () => {
-    const wrapper = getWrapper(storeWithGraph);
-
-    expect(mockCytoscape).toHaveBeenCalledTimes(1);
-    const cyElement = wrapper.find('#cy').element;
-    expect(mockCytoscape.mock.calls[0][0]).toStrictEqual({
-      container: cyElement,
-      style: [
-        {
-          selector: 'node',
-          style: {
-            width: '10px',
-            height: '10px',
-            content: 'data(key0)',
-            'font-size': '7px',
-            'background-color': 'darkblue',
-            'border-style': 'solid',
-          },
-        },
-        {
-          selector: 'node[ref_query = "query"]',
-          style: {
-            'border-color': 'red',
-            'border-width': '2px',
-          },
-        },
-        {
-          selector: 'node[ref_query = "ref"]',
-          style: {
-            'border-color': 'black',
-            'border-width': '1px',
-          },
-        },
-        {
-          selector: 'edge',
-          style: {
-            width: '2px',
-            'line-color': 'steelblue',
-          },
-        },
-      ],
-      layout: {
-        name: 'grid',
-      },
+    const storeNoGraph = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {
+                    2: {
+                        cluster: "2"
+                    }
+                }
+            }
+        }),
+        actions: {
+            getGraphml
+        }
     });
-    expect(mockReady).toHaveBeenCalledTimes(1);
 
-    // Expect that calling the method passed to ready as a parameter will in turn call graphml
-    const readyParam = mockReady.mock.calls[0][0];
-    readyParam();
-    expect(mockGraphMl).toHaveBeenCalledTimes(2);
-    expect(mockGraphMl.mock.calls[0][0]).toStrictEqual({ layoutBy: 'cose' });
-    expect(mockGraphMl.mock.calls[1][0]).toBe('<graph></graph>');
-  });
+    const storeWithGraph = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {
+                    2: {
+                        cluster: "2",
+                        graph: "<graph></graph>"
+                    }
+                }
+            }
+        }),
+        actions: {
+            getGraphml
+        }
+    });
+
+    const getWrapper = (store: Store<RootState>) => mount(CytoscapeGraph, {
+        propsData: {
+            cluster: 2
+        },
+        global: {
+            plugins: [store]
+        }
+    } as any);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("does a wrapper exist", () => {
+        const wrapper = getWrapper(storeNoGraph);
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("getGraph() is called when no graph available", () => {
+        getWrapper(storeNoGraph);
+        expect(getGraphml).toHaveBeenCalledTimes(1);
+    });
+
+    test("cytoscape methods called as expected", () => {
+        const wrapper = getWrapper(storeWithGraph);
+
+        expect(mockCytoscape).toHaveBeenCalledTimes(1);
+        const cyElement = wrapper.find("#cy").element;
+        expect(mockCytoscape.mock.calls[0][0]).toStrictEqual({
+            container: cyElement,
+            style: [
+                {
+                    selector: "node",
+                    style: {
+                        width: "10px",
+                        height: "10px",
+                        content: "data(key0)",
+                        "font-size": "7px",
+                        "background-color": "darkblue",
+                        "border-style": "solid"
+                    }
+                },
+                {
+                    selector: 'node[ref_query = "query"]',
+                    style: {
+                        "border-color": "red",
+                        "border-width": "2px"
+                    }
+                },
+                {
+                    selector: 'node[ref_query = "ref"]',
+                    style: {
+                        "border-color": "black",
+                        "border-width": "1px"
+                    }
+                },
+                {
+                    selector: "edge",
+                    style: {
+                        width: "2px",
+                        "line-color": "steelblue"
+                    }
+                }
+            ],
+            layout: {
+                name: "grid"
+            }
+        });
+        expect(mockReady).toHaveBeenCalledTimes(1);
+
+        // Expect that calling the method passed to ready as a parameter will in turn call graphml
+        const readyParam = mockReady.mock.calls[0][0];
+        readyParam();
+        expect(mockGraphMl).toHaveBeenCalledTimes(2);
+        expect(mockGraphMl.mock.calls[0][0]).toStrictEqual({ layoutBy: "cose" });
+        expect(mockGraphMl.mock.calls[1][0]).toBe("<graph></graph>");
+    });
 });

--- a/app/client/tests/unit/components/DownloadZip.spec.ts
+++ b/app/client/tests/unit/components/DownloadZip.spec.ts
@@ -1,45 +1,45 @@
-import DownloadZip from '@/components/DownloadZip.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import DownloadZip from "@/components/DownloadZip.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('DownloadZip button', () => {
-  const getZip = jest.fn();
+describe("DownloadZip button", () => {
+    const getZip = jest.fn();
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {
-          someHash: {
-            hash: 'someHash',
-            filename: 'example.fa',
-            sketch: 'sketch',
-          },
-        },
-        perCluster: {},
-      },
-    }),
-    actions: {
-      getZip,
-    },
-  });
-  const wrapper = mount(DownloadZip, {
-    global: {
-      plugins: [store],
-    },
-  });
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {
+                    someHash: {
+                        hash: "someHash",
+                        filename: "example.fa",
+                        sketch: "sketch"
+                    }
+                },
+                perCluster: {}
+            }
+        }),
+        actions: {
+            getZip
+        }
+    });
+    const wrapper = mount(DownloadZip, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
-  it('onClick triggers action to download zip data', () => {
-    wrapper.vm.onClick();
-    expect(getZip).toHaveBeenCalledTimes(1);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
+    it("onClick triggers action to download zip data", () => {
+        wrapper.vm.onClick();
+        expect(getZip).toHaveBeenCalledTimes(1);
+    });
 });

--- a/app/client/tests/unit/components/DropZone.spec.ts
+++ b/app/client/tests/unit/components/DropZone.spec.ts
@@ -1,68 +1,68 @@
-const mockGetRootProps = jest.fn().mockReturnValue({ rprop: 'rval' });
-const mockGetInputProps = jest.fn().mockReturnValue({ iprop: 'ival' });
+const mockGetRootProps = jest.fn().mockReturnValue({ rprop: "rval" });
+const mockGetInputProps = jest.fn().mockReturnValue({ iprop: "ival" });
 const mockUseDropzone = jest.fn().mockReturnValue({
-  getRootProps: mockGetRootProps,
-  getInputProps: mockGetInputProps,
-  isDragActive: false,
+    getRootProps: mockGetRootProps,
+    getInputProps: mockGetInputProps,
+    isDragActive: false
 });
-jest.mock('vue3-dropzone', () => ({
-  useDropzone: mockUseDropzone,
+jest.mock("vue3-dropzone", () => ({
+    useDropzone: mockUseDropzone
 }));
 
 /* eslint-disable import/first */
-import DropZone from '@/components/DropZone.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import DropZone from "@/components/DropZone.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('Dropzone', () => {
-  const processFiles = jest.fn();
+describe("Dropzone", () => {
+    const processFiles = jest.fn();
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-    }),
-    actions: {
-      processFiles,
-    },
-  });
-  const wrapper = mount(DropZone, {
-    global: {
-      plugins: [store],
-    },
-  });
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            }
+        }),
+        actions: {
+            processFiles
+        }
+    });
+    const wrapper = mount(DropZone, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  it('processes dropped files', () => {
-    const file = {
-      name: 'sample.fa',
-    };
+    it("processes dropped files", () => {
+        const file = {
+            name: "sample.fa"
+        };
 
-    expect(mockUseDropzone).toHaveBeenCalledTimes(1);
-    expect(mockUseDropzone.mock.calls[0][0].accept).toStrictEqual(['.fa', '.fasta']);
-    wrapper.vm.onDrop([file]);
-    expect(processFiles).toHaveBeenCalledTimes(1);
-    expect(processFiles.mock.calls[0][1]).toStrictEqual([file]);
-  });
+        expect(mockUseDropzone).toHaveBeenCalledTimes(1);
+        expect(mockUseDropzone.mock.calls[0][0].accept).toStrictEqual([".fa", ".fasta"]);
+        wrapper.vm.onDrop([file]);
+        expect(processFiles).toHaveBeenCalledTimes(1);
+        expect(processFiles.mock.calls[0][1]).toStrictEqual([file]);
+    });
 
-  it('sets dropzone props', () => {
-    expect(wrapper.find('.dropzone').attributes('rprop')).toBe('rval');
-    expect(wrapper.find('input').attributes('iprop')).toBe('ival');
-  });
+    it("sets dropzone props", () => {
+        expect(wrapper.find(".dropzone").attributes("rprop")).toBe("rval");
+        expect(wrapper.find("input").attributes("iprop")).toBe("ival");
+    });
 
-  it('displays text for !isDragActive', () => {
-    expect(wrapper.find('.dropzone').text()).toBe('Drag and drop your fasta files here, or click to select files');
-  });
+    it("displays text for !isDragActive", () => {
+        expect(wrapper.find(".dropzone").text()).toBe("Drag and drop your fasta files here, or click to select files");
+    });
 });

--- a/app/client/tests/unit/components/DropZoneActive.spec.ts
+++ b/app/client/tests/unit/components/DropZoneActive.spec.ts
@@ -1,42 +1,42 @@
-const mockGetRootProps = jest.fn().mockReturnValue({ rprop: 'rval' });
-const mockGetInputProps = jest.fn().mockReturnValue({ iprop: 'ival' });
+const mockGetRootProps = jest.fn().mockReturnValue({ rprop: "rval" });
+const mockGetInputProps = jest.fn().mockReturnValue({ iprop: "ival" });
 const mockUseDropzoneActive = jest.fn().mockReturnValue({
-  getRootProps: mockGetRootProps,
-  getInputProps: mockGetInputProps,
-  isDragActive: true,
+    getRootProps: mockGetRootProps,
+    getInputProps: mockGetInputProps,
+    isDragActive: true
 });
-jest.mock('vue3-dropzone', () => ({
-  useDropzone: mockUseDropzoneActive,
+jest.mock("vue3-dropzone", () => ({
+    useDropzone: mockUseDropzoneActive
 }));
 
 /* eslint-disable import/first */
-import DropZone from '@/components/DropZone.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import DropZone from "@/components/DropZone.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('Dropzone', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(DropZone, {
-    global: {
-      plugins: [store],
-    },
-  });
+describe("Dropzone", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(DropZone, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  it('displays text for isDragActive', () => {
-    expect(wrapper.find('.dropzone').text()).toBe('Drop the files here ...');
-  });
+    it("displays text for isDragActive", () => {
+        expect(wrapper.find(".dropzone").text()).toBe("Drop the files here ...");
+    });
 });

--- a/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
+++ b/app/client/tests/unit/components/GenerateMicroreactURL.spec.ts
@@ -1,204 +1,204 @@
-import GenerateMicroreactURL from '@/components/GenerateMicroreactURL.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import GenerateMicroreactURL from "@/components/GenerateMicroreactURL.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('Generate Microreact URL button with no token submitted', () => {
-  const buildMicroreactURL = jest.fn();
+describe("Generate Microreact URL button with no token submitted", () => {
+    const buildMicroreactURL = jest.fn();
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-      microreactToken: null,
-      errors: [],
-    }),
-    actions: {
-      buildMicroreactURL,
-    },
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    global: {
-      plugins: [store],
-    },
-  });
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            microreactToken: null,
+            errors: []
+        }),
+        actions: {
+            buildMicroreactURL
+        }
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('on click sets modal visibility to true', () => {
-    expect(wrapper.findAll('button')).toHaveLength(1);
-    expect(wrapper.findAll('Modal')).toHaveLength(0);
-    const button = wrapper.findAll('button')[0];
-    expect(wrapper.vm.isModalVisible).toBe(false);
-    button.trigger('click');
-    expect(wrapper.vm.isModalVisible).toBe(true);
-  });
+    test("on click sets modal visibility to true", () => {
+        expect(wrapper.findAll("button")).toHaveLength(1);
+        expect(wrapper.findAll("Modal")).toHaveLength(0);
+        const button = wrapper.findAll("button")[0];
+        expect(wrapper.vm.isModalVisible).toBe(false);
+        button.trigger("click");
+        expect(wrapper.vm.isModalVisible).toBe(true);
+    });
 });
 
-describe('Modal is visible on isModalVisible: true', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-      microreactToken: 'microreact_token',
-      errors: [],
-    }),
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    data() {
-      return {
-        isModalVisible: true,
-      };
-    },
-    global: {
-      plugins: [store],
-    },
-  });
-  test('Modal appears on isModalVisible: true', () => {
-    expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
-    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('No token submitted yet');
-  });
-});
-
-describe('Modal shows different text when creating URL already returned wrong token error', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-      microreactToken: 'microreact_token',
-      errors: [
-        { error: 'Wrong Token' },
-      ],
-    }),
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    data() {
-      return {
-        isModalVisible: true,
-      };
-    },
-    global: {
-      plugins: [store],
-    },
-  });
-  test('Modal appears on isModalVisible: true', () => {
-    expect(wrapper.findAll('.modalFlex')).toHaveLength(1);
-    expect(wrapper.findAll('.modalFlex')[0].text()).toContain('Your submitted token is invalid');
-  });
-});
-
-describe('Submitting token closes modal and saves token', () => {
-  const buildMicroreactURL = jest.fn();
-
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-      microreactToken: 'microreact_token',
-      errors: [],
-    }),
-    actions: {
-      buildMicroreactURL,
-    },
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    data() {
-      return {
-        isModalVisible: true,
-        token: 'microreact_token',
-      };
-    },
-    global: {
-      plugins: [store],
-    },
-  } as any);
-  test('Modal appears on isModalVisible: true', () => {
-    expect(wrapper.findAll('.modalFlex .btn-standard')).toHaveLength(1);
-    const submitButton = wrapper.findAll('.modalFlex .btn-standard')[0];
-    submitButton.trigger('click');
-    expect(wrapper.vm.isModalVisible).toBe(false);
-    expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('Generates URL when token is available', () => {
-  const buildMicroreactURL = jest.fn();
-
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-      microreactToken: 'microreact_token',
-      errors: [],
-    }),
-    actions: {
-      buildMicroreactURL,
-    },
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    global: {
-      plugins: [store],
-    },
-  });
-
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
-
-  test('on click triggers action to get URL', () => {
-    expect(wrapper.findAll('button')).toHaveLength(1);
-    const button = wrapper.findAll('button')[0];
-    button.trigger('click');
-    expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('Provides link to be redirected to microreact', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {
-          7: {
-            cluster: '7',
-            microreactURL: 'microreact.org/mock',
-          },
+describe("Modal is visible on isModalVisible: true", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            microreactToken: "microreact_token",
+            errors: []
+        })
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        data() {
+            return {
+                isModalVisible: true
+            };
         },
-      },
-      microreactToken: 'microreact_token',
-      errors: [],
-    }),
-  });
-  const wrapper = mount(GenerateMicroreactURL, {
-    propsData: {
-      cluster: 7,
-    },
-    global: {
-      plugins: [store],
-    },
-  } as any);
+        global: {
+            plugins: [store]
+        }
+    });
+    test("Modal appears on isModalVisible: true", () => {
+        expect(wrapper.findAll(".modalFlex")).toHaveLength(1);
+        expect(wrapper.findAll(".modalFlex")[0].text()).toContain("No token submitted yet");
+    });
+});
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+describe("Modal shows different text when creating URL already returned wrong token error", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            microreactToken: "microreact_token",
+            errors: [
+                { error: "Wrong Token" }
+            ]
+        })
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        data() {
+            return {
+                isModalVisible: true
+            };
+        },
+        global: {
+            plugins: [store]
+        }
+    });
+    test("Modal appears on isModalVisible: true", () => {
+        expect(wrapper.findAll(".modalFlex")).toHaveLength(1);
+        expect(wrapper.findAll(".modalFlex")[0].text()).toContain("Your submitted token is invalid");
+    });
+});
 
-  test('get href from state', () => {
-    expect(wrapper.findAll('button')).toHaveLength(0);
-    expect(wrapper.findAll('a')).toHaveLength(1);
-    const link = wrapper.find('a');
-    expect(link.attributes().href).toBe('microreact.org/mock');
-  });
+describe("Submitting token closes modal and saves token", () => {
+    const buildMicroreactURL = jest.fn();
+
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            microreactToken: "microreact_token",
+            errors: []
+        }),
+        actions: {
+            buildMicroreactURL
+        }
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        data() {
+            return {
+                isModalVisible: true,
+                token: "microreact_token"
+            };
+        },
+        global: {
+            plugins: [store]
+        }
+    } as any);
+    test("Modal appears on isModalVisible: true", () => {
+        expect(wrapper.findAll(".modalFlex .btn-standard")).toHaveLength(1);
+        const submitButton = wrapper.findAll(".modalFlex .btn-standard")[0];
+        submitButton.trigger("click");
+        expect(wrapper.vm.isModalVisible).toBe(false);
+        expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("Generates URL when token is available", () => {
+    const buildMicroreactURL = jest.fn();
+
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            microreactToken: "microreact_token",
+            errors: []
+        }),
+        actions: {
+            buildMicroreactURL
+        }
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        global: {
+            plugins: [store]
+        }
+    });
+
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("on click triggers action to get URL", () => {
+        expect(wrapper.findAll("button")).toHaveLength(1);
+        const button = wrapper.findAll("button")[0];
+        button.trigger("click");
+        expect(buildMicroreactURL).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("Provides link to be redirected to microreact", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {
+                    7: {
+                        cluster: "7",
+                        microreactURL: "microreact.org/mock"
+                    }
+                }
+            },
+            microreactToken: "microreact_token",
+            errors: []
+        })
+    });
+    const wrapper = mount(GenerateMicroreactURL, {
+        propsData: {
+            cluster: 7
+        },
+        global: {
+            plugins: [store]
+        }
+    } as any);
+
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("get href from state", () => {
+        expect(wrapper.findAll("button")).toHaveLength(0);
+        expect(wrapper.findAll("a")).toHaveLength(1);
+        const link = wrapper.find("a");
+        expect(link.attributes().href).toBe("microreact.org/mock");
+    });
 });

--- a/app/client/tests/unit/components/NavbarDropdown.spec.ts
+++ b/app/client/tests/unit/components/NavbarDropdown.spec.ts
@@ -1,71 +1,71 @@
-import NavbarDropdown from '@/components/NavbarDropdown.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { RouterLink } from 'vue-router';
-import { mockRootState } from '../../mocks';
-import router from '../../../src/router/index';
+import NavbarDropdown from "@/components/NavbarDropdown.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { RouterLink } from "vue-router";
+import { mockRootState } from "../../mocks";
+import router from "../../../src/router/index";
 
-describe('NavbarDropdown logged in', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-    }),
-  });
-  const wrapper = mount(NavbarDropdown, {
-    global: {
-      plugins: [store, router],
-    },
+describe("NavbarDropdown logged in", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            }
+        })
+    });
+    const wrapper = mount(NavbarDropdown, {
+        global: {
+            plugins: [store, router]
+        }
 
-  });
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('shows all expected links and divider', () => {
-    const routerLinks = wrapper.findAllComponents(RouterLink);
-    expect(routerLinks.length).toBe(3);
-    expect(routerLinks[0].text()).toBe('Home');
-    expect(routerLinks[1].text()).toBe('Project');
-    expect(routerLinks[2].text()).toBe('About');
-    expect(wrapper.find('a#logout-link').text()).toBe('Logout');
-    expect(wrapper.findAll('.dropdown-divider').length).toBe(1);
-  });
+    test("shows all expected links and divider", () => {
+        const routerLinks = wrapper.findAllComponents(RouterLink);
+        expect(routerLinks.length).toBe(3);
+        expect(routerLinks[0].text()).toBe("Home");
+        expect(routerLinks[1].text()).toBe("Project");
+        expect(routerLinks[2].text()).toBe("About");
+        expect(wrapper.find("a#logout-link").text()).toBe("Logout");
+        expect(wrapper.findAll(".dropdown-divider").length).toBe(1);
+    });
 
-  test('shows logged in user text', () => {
-    expect(wrapper.find('#logged-in-user').text()).toBe('Logged in as Jane');
-  });
+    test("shows logged in user text", () => {
+        expect(wrapper.find("#logged-in-user").text()).toBe("Logged in as Jane");
+    });
 });
 
-describe('NavbarDropdown logged out', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState(),
-  });
-  const wrapper = mount(NavbarDropdown, {
-    global: {
-      plugins: [store, router],
-    },
+describe("NavbarDropdown logged out", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState()
+    });
+    const wrapper = mount(NavbarDropdown, {
+        global: {
+            plugins: [store, router]
+        }
 
-  });
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('shows all expected links', () => {
-    const links = wrapper.findAll('a');
-    expect(links.length).toBe(2);
-    expect(links[0].text()).toBe('Home');
-    expect(links[1].text()).toBe('About');
-    expect(wrapper.findAll('.dropdown-divider').length).toBe(0);
-  });
+    test("shows all expected links", () => {
+        const links = wrapper.findAll("a");
+        expect(links.length).toBe(2);
+        expect(links[0].text()).toBe("Home");
+        expect(links[1].text()).toBe("About");
+        expect(wrapper.findAll(".dropdown-divider").length).toBe(0);
+    });
 
-  test('shows no logged in user text', () => {
-    expect(wrapper.find('#logged-in-user').text()).toBe('');
-  });
+    test("shows no logged in user text", () => {
+        expect(wrapper.find("#logged-in-user").text()).toBe("");
+    });
 });

--- a/app/client/tests/unit/components/NetworkVisualisations.spec.ts
+++ b/app/client/tests/unit/components/NetworkVisualisations.spec.ts
@@ -1,53 +1,53 @@
-import NetworkVisualisations from '@/components/NetworkVisualisations.vue';
-import { shallowMount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import NetworkVisualisations from "@/components/NetworkVisualisations.vue";
+import { shallowMount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('Component displays one button per unique cluster and one network graph', () => {
-  const uniqueClusters = jest.fn().mockReturnValue([2, 4, 7, 31]);
+describe("Component displays one button per unique cluster and one network graph", () => {
+    const uniqueClusters = jest.fn().mockReturnValue([2, 4, 7, 31]);
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {
-          2: {
-            cluster: '2',
-            graph: '<graph></graph>',
-          },
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {
+                    2: {
+                        cluster: "2",
+                        graph: "<graph></graph>"
+                    }
+                }
+            }
+        }),
+        getters: {
+            uniqueClusters
+        }
+    });
+    const wrapper = shallowMount(NetworkVisualisations, {
+        propsData: {
+            firstCluster: 2
         },
-      },
-    }),
-    getters: {
-      uniqueClusters,
-    },
-  });
-  const wrapper = shallowMount(NetworkVisualisations, {
-    propsData: {
-      firstCluster: 2,
-    },
-    global: {
-      plugins: [store],
-    },
-  } as any);
+        global: {
+            plugins: [store]
+        }
+    } as any);
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('has all 4 tabs and a graph element for first cluster', () => {
-    expect(wrapper.findAll('.nav-link')).toHaveLength(4);
-    expect(wrapper.findAll('.cytoscape-graph')).toHaveLength(1);
-    const graphComponent = wrapper.findAllComponents('.cytoscape-graph')[0];
-    expect(graphComponent.attributes('cluster')).toBe('2');
-  });
+    test("has all 4 tabs and a graph element for first cluster", () => {
+        expect(wrapper.findAll(".nav-link")).toHaveLength(4);
+        expect(wrapper.findAll(".cytoscape-graph")).toHaveLength(1);
+        const graphComponent = wrapper.findAllComponents(".cytoscape-graph")[0];
+        expect(graphComponent.attributes("cluster")).toBe("2");
+    });
 
-  test('clicking on tabs changes the selected cluster', () => {
-    const secondTabControl = wrapper.findAll('.nav-link')[1];
-    expect(secondTabControl.text()).toBe('Cluster 4');
-    expect(wrapper.vm.selectedCluster).toBe(2);
-    secondTabControl.trigger('click');
-    expect(wrapper.vm.selectedCluster).toBe(4);
-  });
+    test("clicking on tabs changes the selected cluster", () => {
+        const secondTabControl = wrapper.findAll(".nav-link")[1];
+        expect(secondTabControl.text()).toBe("Cluster 4");
+        expect(wrapper.vm.selectedCluster).toBe(2);
+        secondTabControl.trigger("click");
+        expect(wrapper.vm.selectedCluster).toBe(4);
+    });
 });

--- a/app/client/tests/unit/components/ProgressBar.spec.ts
+++ b/app/client/tests/unit/components/ProgressBar.spec.ts
@@ -1,74 +1,74 @@
-import ProgressBar from '@/components/ProgressBar.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import ProgressBar from "@/components/ProgressBar.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('Progress bar', () => {
-  const analysisProgress = jest.fn().mockReturnValue({
-    finished: 1,
-    progress: 0.3333333333333333,
-    total: 3,
-  });
+describe("Progress bar", () => {
+    const analysisProgress = jest.fn().mockReturnValue({
+        finished: 1,
+        progress: 0.3333333333333333,
+        total: 3
+    });
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'queued',
-        network: 'started',
-      },
-    }),
-    getters: {
-      analysisProgress,
-    },
-  });
-  const wrapper = mount(ProgressBar, {
-    global: {
-      plugins: [store],
-    },
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            analysisStatus: {
+                assign: "finished",
+                microreact: "queued",
+                network: "started"
+            }
+        }),
+        getters: {
+            analysisProgress
+        }
+    });
+    const wrapper = mount(ProgressBar, {
+        global: {
+            plugins: [store]
+        }
 
-  });
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  it('gets analysisProgress and displays status', () => {
-    expect(analysisProgress).toHaveBeenCalledTimes(1);
-    expect(wrapper.vm.animated).toBe(true);
-    expect(wrapper.find('.progress-bar').text()).toBe('33.33%');
-  });
+    it("gets analysisProgress and displays status", () => {
+        expect(analysisProgress).toHaveBeenCalledTimes(1);
+        expect(wrapper.vm.animated).toBe(true);
+        expect(wrapper.find(".progress-bar").text()).toBe("33.33%");
+    });
 });
 
-describe('Progress bar finished', () => {
-  const analysisProgress = jest.fn().mockReturnValue({
-    finished: 3,
-    progress: 1,
-    total: 3,
-  });
+describe("Progress bar finished", () => {
+    const analysisProgress = jest.fn().mockReturnValue({
+        finished: 3,
+        progress: 1,
+        total: 3
+    });
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'finished',
-        network: 'finished',
-      },
-    }),
-    getters: {
-      analysisProgress,
-    },
-  });
-  const wrapper = mount(ProgressBar, {
-    global: {
-      plugins: [store],
-    },
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            analysisStatus: {
+                assign: "finished",
+                microreact: "finished",
+                network: "finished"
+            }
+        }),
+        getters: {
+            analysisProgress
+        }
+    });
+    const wrapper = mount(ProgressBar, {
+        global: {
+            plugins: [store]
+        }
 
-  });
+    });
 
-  it('animated is set to false when all analyses finished', () => {
-    expect(wrapper.vm.animated).toBe(false);
-    expect(wrapper.find('.progress-bar').text()).toBe('100.00%');
-  });
+    it("animated is set to false when all analyses finished", () => {
+        expect(wrapper.vm.animated).toBe(false);
+        expect(wrapper.find(".progress-bar").text()).toBe("100.00%");
+    });
 });

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -26,7 +26,12 @@ describe("empty ResultsTable", () => {
 });
 
 describe("ResultsTable complete", () => {
-    const mockTooltipText = "Probability of resistance to:<br/>Penicillin: Very good chance <small>(0.892)</small><br/>Chloramphenicol: Highly unlikely <small>(0.39)</small><br/>Erythromycin: Highly unlikely <small>(0.151)</small><br/>Tetracycline: Highly unlikely <small>(0.453)</small><br/>Cotrim: Almost certainly <small>(0.974)</small>";
+    const mockTooltipText = "Probability of resistance to:<br/>"
+        + "Penicillin: Very good chance <small>(0.892)</small><br/>"
+        + "Chloramphenicol: Highly unlikely <small>(0.39)</small><br/>"
+        + "Erythromycin: Highly unlikely <small>(0.151)</small><br/>"
+        + "Tetracycline: Highly unlikely <small>(0.453)</small><br/>"
+        + "Cotrim: Almost certainly <small>(0.974)</small>";
     const store = new Vuex.Store<RootState>({
         state: mockRootState({
             user: {

--- a/app/client/tests/unit/components/ResultsTable.spec.ts
+++ b/app/client/tests/unit/components/ResultsTable.spec.ts
@@ -1,336 +1,336 @@
-import ResultsTable from '@/components/ResultsTable.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import ResultsTable from "@/components/ResultsTable.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('empty ResultsTable', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      results: {
-        perIsolate: {},
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(ResultsTable, {
-    global: {
-      plugins: [store],
-    },
-  });
+describe("empty ResultsTable", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(ResultsTable, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  test('empty table message is displayed', () => {
-    expect(wrapper.find('div#no-results').text()).toBe('No data uploaded yet');
-    expect(wrapper.find('table').exists()).toBe(false);
-  });
+    test("empty table message is displayed", () => {
+        expect(wrapper.find("div#no-results").text()).toBe("No data uploaded yet");
+        expect(wrapper.find("table").exists()).toBe(false);
+    });
 });
 
-describe('ResultsTable complete', () => {
-  const mockTooltipText = 'Probability of resistance to:<br/>Penicillin: Very good chance <small>(0.892)</small><br/>Chloramphenicol: Highly unlikely <small>(0.39)</small><br/>Erythromycin: Highly unlikely <small>(0.151)</small><br/>Tetracycline: Highly unlikely <small>(0.453)</small><br/>Cotrim: Almost certainly <small>(0.974)</small>';
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'finished',
-        network: 'finished',
-      },
-      results: {
-        perIsolate: {
-          hash1: {
-            hash: 'hash1',
-            filename: 'example1.fa',
-            sketch: 'sketch',
-            cluster: 7,
-            amr: {
-              filename: 'example1.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
+describe("ResultsTable complete", () => {
+    const mockTooltipText = "Probability of resistance to:<br/>Penicillin: Very good chance <small>(0.892)</small><br/>Chloramphenicol: Highly unlikely <small>(0.39)</small><br/>Erythromycin: Highly unlikely <small>(0.151)</small><br/>Tetracycline: Highly unlikely <small>(0.453)</small><br/>Cotrim: Almost certainly <small>(0.974)</small>";
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
             },
-          },
-          hash2: {
-            hash: 'hash2',
-            filename: 'example2.fa',
-            sketch: 'sketch',
-            cluster: 3,
-            amr: {
-              filename: 'example2.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "finished",
+                microreact: "finished",
+                network: "finished"
             },
-          },
-          hash3: {
-            hash: 'hash3',
-            filename: 'example3.fa',
-            sketch: 'sketch',
-            cluster: 7,
-            amr: {
-              filename: 'example3.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
+            results: {
+                perIsolate: {
+                    hash1: {
+                        hash: "hash1",
+                        filename: "example1.fa",
+                        sketch: "sketch",
+                        cluster: 7,
+                        amr: {
+                            filename: "example1.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    },
+                    hash2: {
+                        hash: "hash2",
+                        filename: "example2.fa",
+                        sketch: "sketch",
+                        cluster: 3,
+                        amr: {
+                            filename: "example2.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    },
+                    hash3: {
+                        hash: "hash3",
+                        filename: "example3.fa",
+                        sketch: "sketch",
+                        cluster: 7,
+                        amr: {
+                            filename: "example3.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    }
+                },
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(ResultsTable, {
+        global: {
+            plugins: [store]
+        }
+
+    });
+
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("tableData generates table data", () => {
+        const expectedTable = [
+            {
+                Hash: "hash2",
+                Filename: "example2.fa",
+                Sketch: "\u2714",
+                AMR: {
+                    filename: "example2.fa",
+                    Penicillin: 0.892,
+                    Chloramphenicol: 0.39,
+                    Erythromycin: 0.151,
+                    Tetracycline: 0.453,
+                    Trim_sulfa: 0.974
+                },
+                Cluster: 3,
+                Microreact: "showButton",
+                Network: "showButton",
+                Rowspan: 1
             },
-          },
-        },
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(ResultsTable, {
-    global: {
-      plugins: [store],
-    },
+            {
+                Hash: "hash1",
+                Filename: "example1.fa",
+                Sketch: "\u2714",
+                AMR: {
+                    filename: "example1.fa",
+                    Penicillin: 0.892,
+                    Chloramphenicol: 0.39,
+                    Erythromycin: 0.151,
+                    Tetracycline: 0.453,
+                    Trim_sulfa: 0.974
+                },
+                Cluster: 7,
+                Microreact: "showButton",
+                Network: "showButton",
+                Rowspan: 2
+            },
+            {
+                Hash: "hash3",
+                Filename: "example3.fa",
+                Sketch: "\u2714",
+                AMR: {
+                    filename: "example3.fa",
+                    Penicillin: 0.892,
+                    Chloramphenicol: 0.39,
+                    Erythromycin: 0.151,
+                    Tetracycline: 0.453,
+                    Trim_sulfa: 0.974
+                },
+                Cluster: 7,
+                Microreact: "showButton",
+                Network: "showButton",
+                Rowspan: 0
+            }
+        ];
+        expect(wrapper.vm.tableData).toEqual(expectedTable);
+    });
 
-  });
+    test("getTooltipText generates tooltip text", () => {
+        const mockAMR = {
+            Penicillin: 0.892,
+            Chloramphenicol: 0.39,
+            Erythromycin: 0.151,
+            Tetracycline: 0.453,
+            Trim_sulfa: 0.974
+        };
+        expect(wrapper.vm.getTooltipText(mockAMR)).toBe(mockTooltipText);
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
-
-  test('tableData generates table data', () => {
-    const expectedTable = [
-      {
-        Hash: 'hash2',
-        Filename: 'example2.fa',
-        Sketch: '\u2714',
-        AMR: {
-          filename: 'example2.fa',
-          Penicillin: 0.892,
-          Chloramphenicol: 0.39,
-          Erythromycin: 0.151,
-          Tetracycline: 0.453,
-          Trim_sulfa: 0.974,
-        },
-        Cluster: 3,
-        Microreact: 'showButton',
-        Network: 'showButton',
-        Rowspan: 1,
-      },
-      {
-        Hash: 'hash1',
-        Filename: 'example1.fa',
-        Sketch: '\u2714',
-        AMR: {
-          filename: 'example1.fa',
-          Penicillin: 0.892,
-          Chloramphenicol: 0.39,
-          Erythromycin: 0.151,
-          Tetracycline: 0.453,
-          Trim_sulfa: 0.974,
-        },
-        Cluster: 7,
-        Microreact: 'showButton',
-        Network: 'showButton',
-        Rowspan: 2,
-      },
-      {
-        Hash: 'hash3',
-        Filename: 'example3.fa',
-        Sketch: '\u2714',
-        AMR: {
-          filename: 'example3.fa',
-          Penicillin: 0.892,
-          Chloramphenicol: 0.39,
-          Erythromycin: 0.151,
-          Tetracycline: 0.453,
-          Trim_sulfa: 0.974,
-        },
-        Cluster: 7,
-        Microreact: 'showButton',
-        Network: 'showButton',
-        Rowspan: 0,
-      },
-    ];
-    expect(wrapper.vm.tableData).toEqual(expectedTable);
-  });
-
-  test('getTooltipText generates tooltip text', () => {
-    const mockAMR = {
-      Penicillin: 0.892,
-      Chloramphenicol: 0.39,
-      Erythromycin: 0.151,
-      Tetracycline: 0.453,
-      Trim_sulfa: 0.974,
-    };
-    expect(wrapper.vm.getTooltipText(mockAMR)).toBe(mockTooltipText);
-  });
-
-  test('results are displayed in the table', () => {
+    test("results are displayed in the table", () => {
     // 6 headers exist
-    const headers = wrapper.findAll('th');
-    expect(headers.length).toBe(6);
-    // 3 rows exist
-    const rows = wrapper.findAll('tr');
-    expect(rows.length).toBe(3);
-    // 16 cells exist (3x6 minus two merged cells)
-    const cells = wrapper.findAll('td');
-    expect(cells.length).toBe(16);
-    // first cell in each row displays filenames
-    expect(cells[0].text()).toBe('example2.fa');
-    expect(cells[6].text()).toBe('example1.fa');
-    expect(cells[12].text()).toBe('example3.fa');
-    // microreact & network cells from same cluster are merged
-    expect(cells[10].attributes('rowspan')).toBe('2');
-    expect(cells[11].attributes('rowspan')).toBe('2');
-    // AMR cells have tooltip
-    const amrCells = wrapper.findAll('span');
-    expect(amrCells.length).toBe(3);
-    expect(amrCells[0].attributes('data-bs-original-title')).toBe(mockTooltipText);
-  });
+        const headers = wrapper.findAll("th");
+        expect(headers.length).toBe(6);
+        // 3 rows exist
+        const rows = wrapper.findAll("tr");
+        expect(rows.length).toBe(3);
+        // 16 cells exist (3x6 minus two merged cells)
+        const cells = wrapper.findAll("td");
+        expect(cells.length).toBe(16);
+        // first cell in each row displays filenames
+        expect(cells[0].text()).toBe("example2.fa");
+        expect(cells[6].text()).toBe("example1.fa");
+        expect(cells[12].text()).toBe("example3.fa");
+        // microreact & network cells from same cluster are merged
+        expect(cells[10].attributes("rowspan")).toBe("2");
+        expect(cells[11].attributes("rowspan")).toBe("2");
+        // AMR cells have tooltip
+        const amrCells = wrapper.findAll("span");
+        expect(amrCells.length).toBe(3);
+        expect(amrCells[0].attributes("data-bs-original-title")).toBe(mockTooltipText);
+    });
 });
 
-describe('ResultsTable incomplete before webworker is ready', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      submitStatus: null,
-      analysisStatus: {
-        assign: null,
-        microreact: null,
-        network: null,
-      },
-      results: {
-        perIsolate: {
-          hash1: {
-            hash: 'hash1',
-            filename: 'example1.fa',
-          },
-          hash2: {
-            hash: 'hash2',
-            filename: 'example2.fa',
-          },
-          hash3: {
-            hash: 'hash3',
-            filename: 'example3.fa',
-          },
-        },
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(ResultsTable, {
-    global: {
-      plugins: [store],
-    },
+describe("ResultsTable incomplete before webworker is ready", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            submitStatus: null,
+            analysisStatus: {
+                assign: null,
+                microreact: null,
+                network: null
+            },
+            results: {
+                perIsolate: {
+                    hash1: {
+                        hash: "hash1",
+                        filename: "example1.fa"
+                    },
+                    hash2: {
+                        hash: "hash2",
+                        filename: "example2.fa"
+                    },
+                    hash3: {
+                        hash: "hash3",
+                        filename: "example3.fa"
+                    }
+                },
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(ResultsTable, {
+        global: {
+            plugins: [store]
+        }
 
-  });
+    });
 
-  test('filenames are displayed in the table', () => {
-    const cells = wrapper.findAll('td');
-    // cells not yet merged
-    expect(cells.length).toBe(9);
-    // filenames not yet sorted by cluster
-    expect(cells[0].text()).toBe('example1.fa');
-    expect(cells[3].text()).toBe('example2.fa');
-    expect(cells[6].text()).toBe('example3.fa');
-  });
+    test("filenames are displayed in the table", () => {
+        const cells = wrapper.findAll("td");
+        // cells not yet merged
+        expect(cells.length).toBe(9);
+        // filenames not yet sorted by cluster
+        expect(cells[0].text()).toBe("example1.fa");
+        expect(cells[3].text()).toBe("example2.fa");
+        expect(cells[6].text()).toBe("example3.fa");
+    });
 
-  test('sketch and AMR columns show processing', () => {
-    const cells = wrapper.findAll('td');
-    expect(cells[1].text()).toBe('processing');
-    expect(cells[4].text()).toBe('processing');
-    expect(cells[7].text()).toBe('processing');
-    expect(cells[2].text()).toBe('processing');
-    expect(cells[5].text()).toBe('processing');
-    expect(cells[8].text()).toBe('processing');
-  });
+    test("sketch and AMR columns show processing", () => {
+        const cells = wrapper.findAll("td");
+        expect(cells[1].text()).toBe("processing");
+        expect(cells[4].text()).toBe("processing");
+        expect(cells[7].text()).toBe("processing");
+        expect(cells[2].text()).toBe("processing");
+        expect(cells[5].text()).toBe("processing");
+        expect(cells[8].text()).toBe("processing");
+    });
 });
 
-describe('ResultsTable incomplete after submission', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'started',
-        microreact: 'waiting',
-        network: 'waiting',
-      },
-      results: {
-        perIsolate: {
-          hash1: {
-            hash: 'hash1',
-            filename: 'example1.fa',
-            sketch: 'sketch',
-            amr: {
-              filename: 'example1.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
+describe("ResultsTable incomplete after submission", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
             },
-          },
-          hash2: {
-            hash: 'hash2',
-            filename: 'example2.fa',
-            sketch: 'sketch',
-            amr: {
-              filename: 'example2.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "started",
+                microreact: "waiting",
+                network: "waiting"
             },
-          },
-          hash3: {
-            hash: 'hash3',
-            filename: 'example3.fa',
-            sketch: 'sketch',
-            amr: {
-              filename: 'example3.fa',
-              Penicillin: 0.892,
-              Chloramphenicol: 0.39,
-              Erythromycin: 0.151,
-              Tetracycline: 0.453,
-              Trim_sulfa: 0.974,
-            },
-          },
-        },
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(ResultsTable, {
-    global: {
-      plugins: [store],
-    },
+            results: {
+                perIsolate: {
+                    hash1: {
+                        hash: "hash1",
+                        filename: "example1.fa",
+                        sketch: "sketch",
+                        amr: {
+                            filename: "example1.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    },
+                    hash2: {
+                        hash: "hash2",
+                        filename: "example2.fa",
+                        sketch: "sketch",
+                        amr: {
+                            filename: "example2.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    },
+                    hash3: {
+                        hash: "hash3",
+                        filename: "example3.fa",
+                        sketch: "sketch",
+                        amr: {
+                            filename: "example3.fa",
+                            Penicillin: 0.892,
+                            Chloramphenicol: 0.39,
+                            Erythromycin: 0.151,
+                            Tetracycline: 0.453,
+                            Trim_sulfa: 0.974
+                        }
+                    }
+                },
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(ResultsTable, {
+        global: {
+            plugins: [store]
+        }
 
-  });
+    });
 
-  test('results are displayed in the table', () => {
-    const cells = wrapper.findAll('td');
-    // cells not yet merged
-    expect(cells.length).toBe(18);
-    // filenames not yet sorted by cluster
-    expect(cells[0].text()).toBe('example1.fa');
-    expect(cells[6].text()).toBe('example2.fa');
-    expect(cells[12].text()).toBe('example3.fa');
-    // cluster, microreact and network cells show analysis status
-    expect(cells[3].text()).toBe('started');
-    expect(cells[4].text()).toBe('waiting');
-    expect(cells[5].text()).toBe('waiting');
-  });
+    test("results are displayed in the table", () => {
+        const cells = wrapper.findAll("td");
+        // cells not yet merged
+        expect(cells.length).toBe(18);
+        // filenames not yet sorted by cluster
+        expect(cells[0].text()).toBe("example1.fa");
+        expect(cells[6].text()).toBe("example2.fa");
+        expect(cells[12].text()).toBe("example3.fa");
+        // cluster, microreact and network cells show analysis status
+        expect(cells[3].text()).toBe("started");
+        expect(cells[4].text()).toBe("waiting");
+        expect(cells[5].text()).toBe("waiting");
+    });
 });

--- a/app/client/tests/unit/components/SelectAction.spec.ts
+++ b/app/client/tests/unit/components/SelectAction.spec.ts
@@ -1,94 +1,94 @@
-import SelectAction from '@/components/SelectAction.vue';
-import {mount, VueWrapper} from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import SelectAction from "@/components/SelectAction.vue";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('SelectAction', () => {
-  const getUser = jest.fn();
-  const setProjectName = jest.fn();
-  const mockRouter = {
-    push: jest.fn(),
-  };
+describe("SelectAction", () => {
+    const getUser = jest.fn();
+    const setProjectName = jest.fn();
+    const mockRouter = {
+        push: jest.fn()
+    };
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-    }),
-    actions: {
-      getUser,
-    },
-    mutations: {
-      setProjectName,
-    },
-  });
-  const getWrapper = () => mount(SelectAction, {
-    global: {
-      plugins: [store],
-      mocks: {
-        $router: mockRouter,
-      },
-    },
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            }
+        }),
+        actions: {
+            getUser
+        },
+        mutations: {
+            setProjectName
+        }
+    });
+    const getWrapper = () => mount(SelectAction, {
+        global: {
+            plugins: [store],
+            mocks: {
+                $router: mockRouter
+            }
+        }
 
-  });
+    });
 
-  let wrapper: VueWrapper;
+    let wrapper: VueWrapper;
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-    wrapper = getWrapper();
-  });
+    beforeEach(() => {
+        jest.resetAllMocks();
+        wrapper = getWrapper();
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  test('gets user information on mount', () => {
-    expect(getUser).toHaveBeenCalledTimes(1);
-  });
+    test("gets user information on mount", () => {
+        expect(getUser).toHaveBeenCalledTimes(1);
+    });
 
-  test('displays as expected', () => {
-    const input = wrapper.find('input#create-project-name');
-    expect(input.text()).toBe('');
-    expect(input.attributes('placeholder')).toBe('Project name');
-    const button = wrapper.find('button#create-project-btn');
-    expect(button.text()).toBe('Create new project');
-    expect((button.element as HTMLButtonElement).disabled).toBe(true);
-  });
+    test("displays as expected", () => {
+        const input = wrapper.find("input#create-project-name");
+        expect(input.text()).toBe("");
+        expect(input.attributes("placeholder")).toBe("Project name");
+        const button = wrapper.find("button#create-project-btn");
+        expect(button.text()).toBe("Create new project");
+        expect((button.element as HTMLButtonElement).disabled).toBe(true);
+    });
 
-  test('enter name and click button sets project name and loads project page', async () => {
-    const input = wrapper.find('#create-project-name');
-    await input.setValue('test name');
-    const button = wrapper.find('#create-project-btn');
-    expect((button.element as HTMLButtonElement).disabled).toBe(false);
-    await button.trigger('click');
+    test("enter name and click button sets project name and loads project page", async () => {
+        const input = wrapper.find("#create-project-name");
+        await input.setValue("test name");
+        const button = wrapper.find("#create-project-btn");
+        expect((button.element as HTMLButtonElement).disabled).toBe(false);
+        await button.trigger("click");
 
-    expect(setProjectName).toHaveBeenCalledTimes(1);
-    expect(setProjectName.mock.calls[0][1]).toBe('test name');
-    expect(mockRouter.push).toHaveBeenCalledTimes(1);
-    expect(mockRouter.push).toHaveBeenCalledWith('/project');
-  });
+        expect(setProjectName).toHaveBeenCalledTimes(1);
+        expect(setProjectName.mock.calls[0][1]).toBe("test name");
+        expect(mockRouter.push).toHaveBeenCalledTimes(1);
+        expect(mockRouter.push).toHaveBeenCalledWith("/project");
+    });
 
-  test('enter name and press enter sets project name and loads project page', async () => {
-    const input = wrapper.find('#create-project-name');
-    await input.setValue('test name');
-    await input.trigger('keyup.enter');
+    test("enter name and press enter sets project name and loads project page", async () => {
+        const input = wrapper.find("#create-project-name");
+        await input.setValue("test name");
+        await input.trigger("keyup.enter");
 
-    expect(setProjectName).toHaveBeenCalledTimes(1);
-    expect(setProjectName.mock.calls[0][1]).toBe('test name');
-    expect(mockRouter.push).toHaveBeenCalledTimes(1);
-    expect(mockRouter.push).toHaveBeenCalledWith('/project');
-  });
+        expect(setProjectName).toHaveBeenCalledTimes(1);
+        expect(setProjectName.mock.calls[0][1]).toBe("test name");
+        expect(mockRouter.push).toHaveBeenCalledTimes(1);
+        expect(mockRouter.push).toHaveBeenCalledWith("/project");
+    });
 
-  test('pressing enter while input is empty does nothing', async () => {
-    const input = wrapper.find('#create-project-name');
-    await input.trigger('keyup.enter');
+    test("pressing enter while input is empty does nothing", async () => {
+        const input = wrapper.find("#create-project-name");
+        await input.trigger("keyup.enter");
 
-    expect(setProjectName).toHaveBeenCalledTimes(0);
-    expect(mockRouter.push).toHaveBeenCalledTimes(0);
-  });
+        expect(setProjectName).toHaveBeenCalledTimes(0);
+        expect(mockRouter.push).toHaveBeenCalledTimes(0);
+    });
 });

--- a/app/client/tests/unit/components/StartButton.spec.ts
+++ b/app/client/tests/unit/components/StartButton.spec.ts
@@ -1,133 +1,133 @@
-import StartButton from '@/components/StartButton.vue';
-import { mount } from '@vue/test-utils';
-import { RootState } from '@/store/state';
-import Vuex from 'vuex';
-import { mockRootState } from '../../mocks';
+import StartButton from "@/components/StartButton.vue";
+import { mount } from "@vue/test-utils";
+import { RootState } from "@/store/state";
+import Vuex from "vuex";
+import { mockRootState } from "../../mocks";
 
-describe('StartButton', () => {
-  const runPoppunk = jest.fn();
-  const getStatus = jest.fn();
-  const getAssignResult = jest.fn();
-  const setSubmitStatus = jest.fn();
-  const setStatusInterval = jest.fn();
-  const startStatusPolling = jest.fn();
-  const submitData = jest.fn();
+describe("StartButton", () => {
+    const runPoppunk = jest.fn();
+    const getStatus = jest.fn();
+    const getAssignResult = jest.fn();
+    const setSubmitStatus = jest.fn();
+    const setStatusInterval = jest.fn();
+    const startStatusPolling = jest.fn();
+    const submitData = jest.fn();
 
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {
-          someHash: {
-            hash: 'someHash',
-            filename: 'example.fa',
-            sketch: 'sketch',
-          },
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {
+                    someHash: {
+                        hash: "someHash",
+                        filename: "example.fa",
+                        sketch: "sketch"
+                    }
+                },
+                perCluster: {}
+            }
+        }),
+        actions: {
+            runPoppunk,
+            getStatus,
+            getAssignResult,
+            startStatusPolling,
+            submitData
         },
-        perCluster: {},
-      },
-    }),
-    actions: {
-      runPoppunk,
-      getStatus,
-      getAssignResult,
-      startStatusPolling,
-      submitData,
-    },
-    mutations: {
-      setSubmitStatus,
-      setStatusInterval,
-    },
-  });
-  const wrapper = mount(StartButton, {
-    global: {
-      plugins: [store],
-    },
+        mutations: {
+            setSubmitStatus,
+            setStatusInterval
+        }
+    });
+    const wrapper = mount(StartButton, {
+        global: {
+            plugins: [store]
+        }
 
-  });
+    });
 
-  test('does a wrapper exist', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
+    test("does a wrapper exist", () => {
+        expect(wrapper.exists()).toBe(true);
+    });
 
-  it('onClick triggers actions', () => {
-    wrapper.vm.onClick();
-    expect(submitData).toHaveBeenCalledTimes(1);
-  });
+    it("onClick triggers actions", () => {
+        wrapper.vm.onClick();
+        expect(submitData).toHaveBeenCalledTimes(1);
+    });
 });
 
-describe('StartButton disabled', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {
-          someHash: {
-            hash: 'someHash',
-            filename: 'example.fa',
-            sketch: 'sketch',
-          },
-          someHash2: {
-            hash: 'someHash2',
-            filename: 'example2.fa',
-          },
-        },
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(StartButton, {
-    global: {
-      plugins: [store],
-    },
-  });
+describe("StartButton disabled", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {
+                    someHash: {
+                        hash: "someHash",
+                        filename: "example.fa",
+                        sketch: "sketch"
+                    },
+                    someHash2: {
+                        hash: "someHash2",
+                        filename: "example2.fa"
+                    }
+                },
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(StartButton, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  it('disables Button when not all sketches are ready', () => {
-    expect(wrapper.find('button').attributes('class')).toContain('disabled');
-  });
+    it("disables Button when not all sketches are ready", () => {
+        expect(wrapper.find("button").attributes("class")).toContain("disabled");
+    });
 });
 
-describe('StartButton disabled after submit', () => {
-  const store = new Vuex.Store<RootState>({
-    state: mockRootState({
-      submitStatus: 'submitted',
-      user: {
-        name: 'Jane',
-        id: '543653d45',
-        provider: 'google',
-      },
-      results: {
-        perIsolate: {
-          someHash: {
-            hash: 'someHash',
-            filename: 'example.fa',
-            sketch: 'sketch',
-          },
-          someHash2: {
-            hash: 'someHash2',
-            filename: 'example2.fa',
-            sketch: 'sketch',
-          },
-        },
-        perCluster: {},
-      },
-    }),
-  });
-  const wrapper = mount(StartButton, {
-    global: {
-      plugins: [store],
-    },
-  });
+describe("StartButton disabled after submit", () => {
+    const store = new Vuex.Store<RootState>({
+        state: mockRootState({
+            submitStatus: "submitted",
+            user: {
+                name: "Jane",
+                id: "543653d45",
+                provider: "google"
+            },
+            results: {
+                perIsolate: {
+                    someHash: {
+                        hash: "someHash",
+                        filename: "example.fa",
+                        sketch: "sketch"
+                    },
+                    someHash2: {
+                        hash: "someHash2",
+                        filename: "example2.fa",
+                        sketch: "sketch"
+                    }
+                },
+                perCluster: {}
+            }
+        })
+    });
+    const wrapper = mount(StartButton, {
+        global: {
+            plugins: [store]
+        }
+    });
 
-  it('disables Button when not all sketches are ready', () => {
-    expect(wrapper.find('button').attributes('class')).toContain('disabled');
-  });
+    it("disables Button when not all sketches are ready", () => {
+        expect(wrapper.find("button").attributes("class")).toContain("disabled");
+    });
 });

--- a/app/client/tests/unit/router.spec.ts
+++ b/app/client/tests/unit/router.spec.ts
@@ -1,29 +1,29 @@
-import router from '@/router/index';
+import router from "@/router/index";
 
-describe('router', () => {
-  const routes = router.getRoutes();
+describe("router", () => {
+    const routes = router.getRoutes();
 
-  it('defines expected routes', () => {
-    expect(routes.length).toBe(3);
-    expect(routes[0].name).toBe('home');
-    expect(routes[0].path).toBe('/');
+    it("defines expected routes", () => {
+        expect(routes.length).toBe(3);
+        expect(routes[0].name).toBe("home");
+        expect(routes[0].path).toBe("/");
 
-    expect(routes[1].name).toBe('about');
-    expect(routes[1].path).toBe('/about');
+        expect(routes[1].name).toBe("about");
+        expect(routes[1].path).toBe("/about");
 
-    expect(routes[2].name).toBe('project');
-    expect(routes[2].path).toBe('/project');
-  });
+        expect(routes[2].name).toBe("project");
+        expect(routes[2].path).toBe("/project");
+    });
 
-  it('Home route loads Home component', () => {
-    expect(routes[0].components.default.name).toBe('HomeView');
-  });
+    it("Home route loads Home component", () => {
+        expect(routes[0].components.default.name).toBe("HomeView");
+    });
 
-  it('About route loads About component', async () => {
-    expect(routes[1].components.default.name).toBe('AboutView');
-  });
+    it("About route loads About component", async () => {
+        expect(routes[1].components.default.name).toBe("AboutView");
+    });
 
-  it('Project route loads Project component', async () => {
-    expect(routes[2].components.default.name).toBe('ProjectView');
-  });
+    it("Project route loads Project component", async () => {
+        expect(routes[2].components.default.name).toBe("ProjectView");
+    });
 });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -1,16 +1,16 @@
-import actions from '@/store/actions';
-import versionInfo from '@/resources/versionInfo.json';
-import { Md5 } from 'ts-md5/dist/md5';
-import config from '../../../src/settings/development/config';
-import { mockAxios, mockRootState } from '../../mocks';
+import actions from "@/store/actions";
+import versionInfo from "@/resources/versionInfo.json";
+import { Md5 } from "ts-md5/dist/md5";
+import config from "../../../src/settings/development/config";
+import { mockAxios, mockRootState } from "../../mocks";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function responseSuccess(data : any) {
-  return {
-    status: 'success',
-    errors: [],
-    data,
-  };
+    return {
+        status: "success",
+        errors: [],
+        data
+    };
 }
 
 class MockWorker implements Partial<Worker> {
@@ -19,309 +19,309 @@ class MockWorker implements Partial<Worker> {
   onmessage: (msg: any) => any
 
   constructor(stringUrl: any) {
-    this.url = stringUrl;
-    this.onmessage = () => {};
+      this.url = stringUrl;
+      this.onmessage = () => {};
   }
 
   postMessage(msg: any) {
-    this.onmessage({ data: msg });
+      this.onmessage({ data: msg });
   }
 }
 
 (window as any).Worker = MockWorker;
 
-describe('Actions', () => {
-  afterEach(() => {
-    mockAxios.reset();
-    jest.clearAllMocks();
-  });
-
-  const serverUrl = config.serverUrl();
-  it('getVersions fetches and commits version info', async () => {
-    mockAxios.onGet(`${serverUrl}/version`).reply(200, versionInfo);
-    const commit = jest.fn();
-    await actions.getVersions({ commit } as any);
-
-    expect(commit).toHaveBeenCalledWith(
-      'setVersions',
-      versionInfo.data,
-    );
-  });
-
-  it('getUser fetches and commits user info', async () => {
-    mockAxios.onGet(`${serverUrl}/user`).reply(200, responseSuccess({ id: '12345', name: 'Beebop', provider: 'google' }));
-    const commit = jest.fn();
-    await actions.getUser({ commit } as any);
-
-    expect(commit).toHaveBeenCalledWith(
-      'setUser',
-      { id: '12345', name: 'Beebop', provider: 'google' },
-    );
-  });
-
-  it('logoutUser makes axios call', async () => {
-    mockAxios.onGet(`${serverUrl}/logout`).reply(200);
-    await actions.logoutUser();
-    expect(mockAxios.history.get[0].url).toEqual(`${serverUrl}/logout`);
-  });
-
-  it('processFiles calculates filehash, adds hash & filename to store and calls setSketch', async () => {
-    const commit = jest.fn();
-    const file = {
-      name: 'sample.fa',
-      text: () => Promise.resolve('ACGTGTAGTCTGACGTAAC'),
-    };
-    await actions.processFiles({ commit }, [file as any]);
-    expect(commit.mock.calls[0]).toEqual([
-      'addFile',
-      { hash: '97f83117a2679651d4044b5ffdc5fd00', name: 'sample.fa' }]);
-    expect(commit.mock.calls[1]).toEqual([
-      'setIsolateValue',
-      { hash: '97f83117a2679651d4044b5ffdc5fd00', fileObject: file }]);
-  });
-
-  it('runPoppunk makes axios call', async () => {
-    const commit = jest.fn();
-    const state = mockRootState({
-      projectName: 'test project',
-      results: {
-        perIsolate: {
-          someFileHash: {
-            filename: 'someFilename',
-            sketch: '{"14":"12345"}',
-          },
-          someFileHash2: {
-            filename: 'someFilename2',
-            sketch: '{"14":"12345"}',
-          },
-        },
-        perCluster: {},
-      },
+describe("Actions", () => {
+    afterEach(() => {
+        mockAxios.reset();
+        jest.clearAllMocks();
     });
-    const expectedHash = Md5.hashStr('someFileHashsomeFilenamesomeFileHash2someFilename2');
-    mockAxios.onPost(`${serverUrl}/poppunk`).reply(200, responseSuccess({
-      assign: 'job-id', microreact: 'job-id', network: 'job-id',
-    }));
-    await actions.runPoppunk({ commit, state } as any);
-    expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/poppunk`);
-    expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({
-      projectHash: expectedHash,
-      projectName: 'test project',
-      sketches: {
-        someFileHash: { 14: '12345' },
-        someFileHash2: { 14: '12345' },
-      },
-      names: {
-        someFileHash: 'someFilename',
-        someFileHash2: 'someFilename2',
-      },
+
+    const serverUrl = config.serverUrl();
+    it("getVersions fetches and commits version info", async () => {
+        mockAxios.onGet(`${serverUrl}/version`).reply(200, versionInfo);
+        const commit = jest.fn();
+        await actions.getVersions({ commit } as any);
+
+        expect(commit).toHaveBeenCalledWith(
+            "setVersions",
+            versionInfo.data
+        );
     });
-    expect(commit.mock.calls[0]).toEqual([
-      'setProjectHash',
-      expectedHash]);
-    expect(commit.mock.calls[1]).toEqual([
-      'setAnalysisStatus',
-      {
-        assign: 'submitted',
-        microreact: 'submitted',
-        network: 'submitted',
-      }]);
-  });
 
-  it('getStatus makes axios call and updates analysisStatus, triggers getAssignResult', async () => {
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'started',
-        microreact: 'waiting',
-        network: 'waiting',
-      },
+    it("getUser fetches and commits user info", async () => {
+        mockAxios.onGet(`${serverUrl}/user`).reply(200, responseSuccess({ id: "12345", name: "Beebop", provider: "google" }));
+        const commit = jest.fn();
+        await actions.getUser({ commit } as any);
+
+        expect(commit).toHaveBeenCalledWith(
+            "setUser",
+            { id: "12345", name: "Beebop", provider: "google" }
+        );
     });
-    mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
-      assign: 'finished', microreact: 'started', network: 'queued',
-    }));
-    await actions.getStatus({ commit, state, dispatch } as any);
-    expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/status`);
-    expect(commit.mock.calls[0]).toEqual([
-      'setAnalysisStatus',
-      {
-        microreact: 'started',
-        network: 'queued',
-        assign: 'finished',
-      },
-    ]);
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch).toHaveBeenCalledWith('getAssignResult');
-  });
 
-  it('getStatus stops updating analysisStatus once all jobs finished', async () => {
-    jest.useFakeTimers();
-    jest.spyOn(global, 'clearInterval');
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'started',
-        network: 'queued',
-      },
-      statusInterval: 202,
+    it("logoutUser makes axios call", async () => {
+        mockAxios.onGet(`${serverUrl}/logout`).reply(200);
+        await actions.logoutUser();
+        expect(mockAxios.history.get[0].url).toEqual(`${serverUrl}/logout`);
     });
-    mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
-      assign: 'finished', microreact: 'finished', network: 'finished',
-    }));
-    await actions.getStatus({ commit, state, dispatch } as any);
-    expect(clearInterval).toHaveBeenCalledTimes(1);
-    expect(clearInterval).toHaveBeenLastCalledWith(202);
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-  });
 
-  it('getStatus stops updating analysisStatus when jobs fail', async () => {
-    jest.useFakeTimers();
-    jest.spyOn(global, 'clearInterval');
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'started',
-        network: 'queued',
-      },
-      statusInterval: 202,
+    it("processFiles calculates filehash, adds hash & filename to store and calls setSketch", async () => {
+        const commit = jest.fn();
+        const file = {
+            name: "sample.fa",
+            text: () => Promise.resolve("ACGTGTAGTCTGACGTAAC")
+        };
+        await actions.processFiles({ commit }, [file as any]);
+        expect(commit.mock.calls[0]).toEqual([
+            "addFile",
+            { hash: "97f83117a2679651d4044b5ffdc5fd00", name: "sample.fa" }]);
+        expect(commit.mock.calls[1]).toEqual([
+            "setIsolateValue",
+            { hash: "97f83117a2679651d4044b5ffdc5fd00", fileObject: file }]);
     });
-    mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
-      assign: 'finished', microreact: 'failed', network: 'failed',
-    }));
-    await actions.getStatus({ commit, state, dispatch } as any);
-    expect(clearInterval).toHaveBeenCalledTimes(1);
-    expect(clearInterval).toHaveBeenLastCalledWith(202);
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-  });
 
-  it('getStatus stops updating analysisStatus when it receives no results from API', async () => {
-    jest.useFakeTimers();
-    jest.spyOn(global, 'clearInterval');
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'submitted',
-        microreact: 'submitted',
-        network: 'submitted',
-      },
-      statusInterval: 202,
+    it("runPoppunk makes axios call", async () => {
+        const commit = jest.fn();
+        const state = mockRootState({
+            projectName: "test project",
+            results: {
+                perIsolate: {
+                    someFileHash: {
+                        filename: "someFilename",
+                        sketch: '{"14":"12345"}'
+                    },
+                    someFileHash2: {
+                        filename: "someFilename2",
+                        sketch: '{"14":"12345"}'
+                    }
+                },
+                perCluster: {}
+            }
+        });
+        const expectedHash = Md5.hashStr("someFileHashsomeFilenamesomeFileHash2someFilename2");
+        mockAxios.onPost(`${serverUrl}/poppunk`).reply(200, responseSuccess({
+            assign: "job-id", microreact: "job-id", network: "job-id"
+        }));
+        await actions.runPoppunk({ commit, state } as any);
+        expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/poppunk`);
+        expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({
+            projectHash: expectedHash,
+            projectName: "test project",
+            sketches: {
+                someFileHash: { 14: "12345" },
+                someFileHash2: { 14: "12345" }
+            },
+            names: {
+                someFileHash: "someFilename",
+                someFileHash2: "someFilename2"
+            }
+        });
+        expect(commit.mock.calls[0]).toEqual([
+            "setProjectHash",
+            expectedHash]);
+        expect(commit.mock.calls[1]).toEqual([
+            "setAnalysisStatus",
+            {
+                assign: "submitted",
+                microreact: "submitted",
+                network: "submitted"
+            }]);
     });
-    mockAxios.onPost(`${serverUrl}/status`).reply(400);
-    await actions.getStatus({ commit, state, dispatch } as any);
-    expect(clearInterval).toHaveBeenCalledTimes(1);
-    expect(clearInterval).toHaveBeenLastCalledWith(202);
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-  });
 
-  it('startStatusPolling sets statusInterval', async () => {
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    await actions.startStatusPolling({ commit, dispatch } as any);
-    expect(commit.mock.calls[0][0]).toEqual('setStatusInterval');
-    expect(commit.mock.calls[0][1]).toEqual(expect.any(Number));
-  });
-
-  it('getAssignResult makes axios call and updates clusters', async () => {
-    const commit = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      results: {
-        perIsolate: {
-          someFileHash: {
-            hash: 'someFileHash',
-          },
-          someFileHash2: {
-            hash: 'someFileHash2',
-          },
-        },
-        perCluster: {},
-      },
+    it("getStatus makes axios call and updates analysisStatus, triggers getAssignResult", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash",
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "started",
+                microreact: "waiting",
+                network: "waiting"
+            }
+        });
+        mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
+            assign: "finished", microreact: "started", network: "queued"
+        }));
+        await actions.getStatus({ commit, state, dispatch } as any);
+        expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/status`);
+        expect(commit.mock.calls[0]).toEqual([
+            "setAnalysisStatus",
+            {
+                microreact: "started",
+                network: "queued",
+                assign: "finished"
+            }
+        ]);
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(dispatch).toHaveBeenCalledWith("getAssignResult");
     });
-    const expResponse = responseSuccess({ 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } });
-    mockAxios.onPost(`${serverUrl}/assignResult`).reply(200, expResponse);
-    await actions.getAssignResult({ commit, state } as any);
-    expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/assignResult`);
-    expect(commit.mock.calls[0]).toEqual([
-      'setClusters',
-      expResponse.data,
-    ]);
-  });
 
-  it('submitData triggers runPoppunk, startStatusPolling and sets submitStatus', async () => {
-    const commit = jest.fn();
-    const dispatch = jest.fn();
-    await actions.submitData({ commit, dispatch } as any);
-    expect(commit.mock.calls[0][0]).toEqual('setSubmitStatus');
-    expect(commit.mock.calls[0][1]).toEqual('submitted');
-    expect(dispatch.mock.calls[0][0]).toEqual('runPoppunk');
-    expect(dispatch.mock.calls[1][0]).toEqual('startStatusPolling');
-  });
-
-  it('getZip makes api call and creates download link', async () => {
-    const createElementSpy = jest.spyOn(document, 'createElement');
-    global.URL.createObjectURL = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
+    it("getStatus stops updating analysisStatus once all jobs finished", async () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, "clearInterval");
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash",
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "finished",
+                microreact: "started",
+                network: "queued"
+            },
+            statusInterval: 202
+        });
+        mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
+            assign: "finished", microreact: "finished", network: "finished"
+        }));
+        await actions.getStatus({ commit, state, dispatch } as any);
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenLastCalledWith(202);
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
-    const data = {
-      type: 'network',
-      cluster: 7,
-    };
-    mockAxios.onPost(`${serverUrl}/downloadZip`).reply(200, { data: 'zipData' });
-    await actions.getZip({ state } as any, data);
-    expect(createElementSpy).toHaveBeenCalledTimes(1);
-    expect(createElementSpy).toHaveBeenCalledWith('a');
-    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
-  });
 
-  it('buildMicroreactURL makes axios call and updates results', async () => {
-    const commit = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
+    it("getStatus stops updating analysisStatus when jobs fail", async () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, "clearInterval");
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash",
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "finished",
+                microreact: "started",
+                network: "queued"
+            },
+            statusInterval: 202
+        });
+        mockAxios.onPost(`${serverUrl}/status`).reply(200, responseSuccess({
+            assign: "finished", microreact: "failed", network: "failed"
+        }));
+        await actions.getStatus({ commit, state, dispatch } as any);
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenLastCalledWith(202);
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
-    const expResponse = responseSuccess({ cluster: 7, url: 'microreact.org/mock' });
-    mockAxios.onPost(`${serverUrl}/microreactURL`).reply(200, expResponse);
-    await actions.buildMicroreactURL({ commit, state } as any, { cluster: 7, token: 'some_token' });
-    expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/microreactURL`);
-    expect(commit.mock.calls[0]).toEqual([
-      'setToken',
-      'some_token',
-    ]);
-    expect(commit.mock.calls[1]).toEqual([
-      'addMicroreactURL',
-      expResponse.data,
-    ]);
-  });
 
-  it('getGraphml makes axios call and updates results', async () => {
-    const commit = jest.fn();
-    const state = mockRootState({
-      projectHash: 'randomHash',
+    it("getStatus stops updating analysisStatus when it receives no results from API", async () => {
+        jest.useFakeTimers();
+        jest.spyOn(global, "clearInterval");
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash",
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "submitted",
+                microreact: "submitted",
+                network: "submitted"
+            },
+            statusInterval: 202
+        });
+        mockAxios.onPost(`${serverUrl}/status`).reply(400);
+        await actions.getStatus({ commit, state, dispatch } as any);
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenLastCalledWith(202);
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
-    const expResponse = responseSuccess({ cluster: 7, graph: '<graph></graph>' });
-    mockAxios.onPost(`${serverUrl}/downloadGraphml`).reply(200, expResponse);
-    await actions.getGraphml({ commit, state } as any, 7);
-    expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/downloadGraphml`);
-    expect(commit.mock.calls[0]).toEqual([
-      'addGraphml',
-      expResponse.data,
-    ]);
-  });
+
+    it("startStatusPolling sets statusInterval", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        await actions.startStatusPolling({ commit, dispatch } as any);
+        expect(commit.mock.calls[0][0]).toEqual("setStatusInterval");
+        expect(commit.mock.calls[0][1]).toEqual(expect.any(Number));
+    });
+
+    it("getAssignResult makes axios call and updates clusters", async () => {
+        const commit = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash",
+            results: {
+                perIsolate: {
+                    someFileHash: {
+                        hash: "someFileHash"
+                    },
+                    someFileHash2: {
+                        hash: "someFileHash2"
+                    }
+                },
+                perCluster: {}
+            }
+        });
+        const expResponse = responseSuccess({ 0: { hash: "someFileHash", cluster: "12" }, 1: { hash: "someFileHash2", cluster: "2" } });
+        mockAxios.onPost(`${serverUrl}/assignResult`).reply(200, expResponse);
+        await actions.getAssignResult({ commit, state } as any);
+        expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/assignResult`);
+        expect(commit.mock.calls[0]).toEqual([
+            "setClusters",
+            expResponse.data
+        ]);
+    });
+
+    it("submitData triggers runPoppunk, startStatusPolling and sets submitStatus", async () => {
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        await actions.submitData({ commit, dispatch } as any);
+        expect(commit.mock.calls[0][0]).toEqual("setSubmitStatus");
+        expect(commit.mock.calls[0][1]).toEqual("submitted");
+        expect(dispatch.mock.calls[0][0]).toEqual("runPoppunk");
+        expect(dispatch.mock.calls[1][0]).toEqual("startStatusPolling");
+    });
+
+    it("getZip makes api call and creates download link", async () => {
+        const createElementSpy = jest.spyOn(document, "createElement");
+        global.URL.createObjectURL = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash"
+        });
+        const data = {
+            type: "network",
+            cluster: 7
+        };
+        mockAxios.onPost(`${serverUrl}/downloadZip`).reply(200, { data: "zipData" });
+        await actions.getZip({ state } as any, data);
+        expect(createElementSpy).toHaveBeenCalledTimes(1);
+        expect(createElementSpy).toHaveBeenCalledWith("a");
+        expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    });
+
+    it("buildMicroreactURL makes axios call and updates results", async () => {
+        const commit = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash"
+        });
+        const expResponse = responseSuccess({ cluster: 7, url: "microreact.org/mock" });
+        mockAxios.onPost(`${serverUrl}/microreactURL`).reply(200, expResponse);
+        await actions.buildMicroreactURL({ commit, state } as any, { cluster: 7, token: "some_token" });
+        expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/microreactURL`);
+        expect(commit.mock.calls[0]).toEqual([
+            "setToken",
+            "some_token"
+        ]);
+        expect(commit.mock.calls[1]).toEqual([
+            "addMicroreactURL",
+            expResponse.data
+        ]);
+    });
+
+    it("getGraphml makes axios call and updates results", async () => {
+        const commit = jest.fn();
+        const state = mockRootState({
+            projectHash: "randomHash"
+        });
+        const expResponse = responseSuccess({ cluster: 7, graph: "<graph></graph>" });
+        mockAxios.onPost(`${serverUrl}/downloadGraphml`).reply(200, expResponse);
+        await actions.getGraphml({ commit, state } as any, 7);
+        expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/downloadGraphml`);
+        expect(commit.mock.calls[0]).toEqual([
+            "addGraphml",
+            expResponse.data
+        ]);
+    });
 });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -49,7 +49,8 @@ describe("Actions", () => {
     });
 
     it("getUser fetches and commits user info", async () => {
-        mockAxios.onGet(`${serverUrl}/user`).reply(200, responseSuccess({ id: "12345", name: "Beebop", provider: "google" }));
+        mockAxios.onGet(`${serverUrl}/user`)
+            .reply(200, responseSuccess({ id: "12345", name: "Beebop", provider: "google" }));
         const commit = jest.fn();
         await actions.getUser({ commit } as any);
 
@@ -254,7 +255,10 @@ describe("Actions", () => {
                 perCluster: {}
             }
         });
-        const expResponse = responseSuccess({ 0: { hash: "someFileHash", cluster: "12" }, 1: { hash: "someFileHash2", cluster: "2" } });
+        const expResponse = responseSuccess({
+            0: { hash: "someFileHash", cluster: "12" },
+            1: { hash: "someFileHash2", cluster: "2" }
+        });
         mockAxios.onPost(`${serverUrl}/assignResult`).reply(200, expResponse);
         await actions.getAssignResult({ commit, state } as any);
         expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/assignResult`);

--- a/app/client/tests/unit/store/getters.spec.ts
+++ b/app/client/tests/unit/store/getters.spec.ts
@@ -1,54 +1,54 @@
-import { getters } from '@/store/getters';
-import { mockRootState } from '../../mocks';
+import { getters } from "@/store/getters";
+import { mockRootState } from "../../mocks";
 
-describe('getters', () => {
-  it('calculates analysisProgress', () => {
-    const state = mockRootState({
-      projectHash: 'randomHash',
-      submitStatus: 'submitted',
-      analysisStatus: {
-        assign: 'finished',
-        microreact: 'started',
-        network: 'queued',
-      },
+describe("getters", () => {
+    it("calculates analysisProgress", () => {
+        const state = mockRootState({
+            projectHash: "randomHash",
+            submitStatus: "submitted",
+            analysisStatus: {
+                assign: "finished",
+                microreact: "started",
+                network: "queued"
+            }
+        });
+        expect(getters.analysisProgress(state, "analysisProgress", state, "analysisProgress")).toStrictEqual({
+            finished: 1,
+            progress: 0.3333333333333333,
+            total: 3
+        });
     });
-    expect(getters.analysisProgress(state, 'analysisProgress', state, 'analysisProgress')).toStrictEqual({
-      finished: 1,
-      progress: 0.3333333333333333,
-      total: 3,
+    it("gets unique clusters", () => {
+        const state = mockRootState({
+            results: {
+                perCluster: {},
+                perIsolate: {
+                    hash1: {
+                        cluster: 4
+                    },
+                    hash2: {
+                        cluster: 2
+                    },
+                    hash3: {
+                        cluster: 7
+                    },
+                    hash4: {
+                        cluster: 4
+                    },
+                    hash5: {
+                        cluster: 31
+                    },
+                    hash6: {
+                        cluster: 2
+                    }
+                }
+            }
+        });
+        expect(getters.uniqueClusters(
+            state,
+            "uniqueClusters",
+            state,
+            "uniqueClusters"
+        )).toStrictEqual([2, 4, 7, 31]);
     });
-  });
-  it('gets unique clusters', () => {
-    const state = mockRootState({
-      results: {
-        perCluster: {},
-        perIsolate: {
-          hash1: {
-            cluster: 4,
-          },
-          hash2: {
-            cluster: 2,
-          },
-          hash3: {
-            cluster: 7,
-          },
-          hash4: {
-            cluster: 4,
-          },
-          hash5: {
-            cluster: 31,
-          },
-          hash6: {
-            cluster: 2,
-          },
-        },
-      },
-    });
-    expect(getters.uniqueClusters(
-      state,
-      'uniqueClusters',
-      state,
-      'uniqueClusters',
-    )).toStrictEqual([2, 4, 7, 31]);
-  });
 });

--- a/app/client/tests/unit/store/index.spec.ts
+++ b/app/client/tests/unit/store/index.spec.ts
@@ -1,22 +1,22 @@
-import actions from '@/store/actions';
-import index from '@/store/index';
-import mutations from '@/store/mutations';
-import { getters } from '@/store/getters';
+import actions from "@/store/actions";
+import index from "@/store/index";
+import mutations from "@/store/mutations";
+import { getters } from "@/store/getters";
 
-describe('store index', () => {
-  it('creates a root state', () => {
-    expect(index).toHaveProperty('state');
-  });
+describe("store index", () => {
+    it("creates a root state", () => {
+        expect(index).toHaveProperty("state");
+    });
 
-  it('has mutations', () => {
-    expect((index as any)._modules.root._rawModule.mutations).toMatchObject(mutations);
-  });
+    it("has mutations", () => {
+        expect((index as any)._modules.root._rawModule.mutations).toMatchObject(mutations);
+    });
 
-  it('has actions', () => {
-    expect((index as any)._modules.root._rawModule.actions).toMatchObject(actions);
-  });
+    it("has actions", () => {
+        expect((index as any)._modules.root._rawModule.actions).toMatchObject(actions);
+    });
 
-  it('has getters', () => {
-    expect((index as any)._modules.root._rawModule.getters).toMatchObject(getters);
-  });
+    it("has getters", () => {
+        expect((index as any)._modules.root._rawModule.getters).toMatchObject(getters);
+    });
 });

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -1,159 +1,159 @@
-import mutations from '@/store/mutations';
-import { ValueTypes } from '@/types';
-import { mockRootState } from '../../mocks';
+import mutations from "@/store/mutations";
+import { ValueTypes } from "@/types";
+import { mockRootState } from "../../mocks";
 
-describe('mutations', () => {
-  it('adds Errors', () => {
-    const state = mockRootState();
-    const mockError = {
-      error: 'Error',
-      detail: 'Detail',
-    };
-    mutations.addError(state, mockError);
-    expect(state.errors).toStrictEqual([mockError]);
-  });
-  it('sets versioninfo', () => {
-    const state = mockRootState();
-    const mockVersioninfo = {
-      data: [{ name: 'beebop', version: '0.1.0' }, { name: 'poppunk', version: '2.4.0' }],
-      errors: [],
-      status: 'success',
-    };
-    mutations.setVersions(state, mockVersioninfo);
-    expect(state.versions).toBe(mockVersioninfo);
-  });
-  it('sets user', () => {
-    const state = mockRootState();
-    const mockUser = { id: '12345', provider: 'google', name: 'Jane' };
-    mutations.setUser(state, mockUser);
-    expect(state.user).toBe(mockUser);
-  });
-  it('adds new file', () => {
-    const state = mockRootState();
-    const mockFileMetadata = { hash: 'someFileHash', name: 'sampleName.fa' };
-    mutations.addFile(state, mockFileMetadata);
-    expect(state.results.perIsolate.someFileHash).toStrictEqual({ hash: 'someFileHash', filename: 'sampleName.fa' });
-  });
-  it('sets sketch values', () => {
-    const state = mockRootState({
-      results: {
-        perIsolate: {
-          someFileHash: {
-            hash: 'someFileHash',
-            filename: 'sampleName.fa',
-          },
-        },
-        perCluster: {},
-      },
+describe("mutations", () => {
+    it("adds Errors", () => {
+        const state = mockRootState();
+        const mockError = {
+            error: "Error",
+            detail: "Detail"
+        };
+        mutations.addError(state, mockError);
+        expect(state.errors).toStrictEqual([mockError]);
     });
-    const { SKETCH } = ValueTypes;
-    const mockIsolateValues = {
-      hash: 'someFileHash',
-      type: SKETCH,
-      result: 'sketch_result',
-    };
-    mutations.setIsolateValue(state, mockIsolateValues);
-    expect(state.results.perIsolate.someFileHash).toStrictEqual({
-      hash: 'someFileHash',
-      filename: 'sampleName.fa',
-      sketch: 'sketch_result',
+    it("sets versioninfo", () => {
+        const state = mockRootState();
+        const mockVersioninfo = {
+            data: [{ name: "beebop", version: "0.1.0" }, { name: "poppunk", version: "2.4.0" }],
+            errors: [],
+            status: "success"
+        };
+        mutations.setVersions(state, mockVersioninfo);
+        expect(state.versions).toBe(mockVersioninfo);
     });
-  });
-  it('sets AMR values', () => {
-    const state = mockRootState({
-      results: {
-        perIsolate: {
-          someFileHash: {
-            hash: 'someFileHash',
-            filename: 'sampleName.fa',
-          },
-        },
-        perCluster: {},
-      },
+    it("sets user", () => {
+        const state = mockRootState();
+        const mockUser = { id: "12345", provider: "google", name: "Jane" };
+        mutations.setUser(state, mockUser);
+        expect(state.user).toBe(mockUser);
     });
-    const { AMR } = ValueTypes;
-    const mockAMR = {
-      hash: 'someFileHash',
-      type: AMR,
-      result: '{ "Penicillin": 0.5, "Chloramphenicol": 0.2 }',
-    };
-    mutations.setIsolateValue(state, mockAMR);
-    expect(state.results.perIsolate.someFileHash).toStrictEqual({
-      hash: 'someFileHash',
-      filename: 'sampleName.fa',
-      amr: { Penicillin: 0.5, Chloramphenicol: 0.2 },
+    it("adds new file", () => {
+        const state = mockRootState();
+        const mockFileMetadata = { hash: "someFileHash", name: "sampleName.fa" };
+        mutations.addFile(state, mockFileMetadata);
+        expect(state.results.perIsolate.someFileHash).toStrictEqual({ hash: "someFileHash", filename: "sampleName.fa" });
     });
-  });
-  it('sets submitStatus', () => {
-    const state = mockRootState();
-    mutations.setSubmitStatus(state, 'submitted');
-    expect(state.submitStatus).toBe('submitted');
-  });
-  it('sets analysisStatus', () => {
-    const state = mockRootState();
-    const statusUpdate = {
-      assign: 'finished',
-      microreact: 'started',
-      network: 'queued',
-    };
-    mutations.setAnalysisStatus(state, statusUpdate);
-    expect(state.analysisStatus).toBe(statusUpdate);
-  });
-  it('sets projectHash', () => {
-    const state = mockRootState();
-    const phash = 'mock-hash';
-    mutations.setProjectHash(state, phash);
-    expect(state.projectHash).toBe(phash);
-  });
-  it('sets statusInterval', () => {
-    const state = mockRootState();
-    const interval = 122;
-    mutations.setStatusInterval(state, interval);
-    expect(state.statusInterval).toBe(interval);
-  });
-  it('sets cluster', () => {
-    const state = mockRootState({
-      results: {
-        perIsolate: {
-          someFileHash: {
-            hash: 'someFileHash',
-          },
-          someFileHash2: {
-            hash: 'someFileHash2',
-          },
-        },
-        perCluster: {},
-      },
+    it("sets sketch values", () => {
+        const state = mockRootState({
+            results: {
+                perIsolate: {
+                    someFileHash: {
+                        hash: "someFileHash",
+                        filename: "sampleName.fa"
+                    }
+                },
+                perCluster: {}
+            }
+        });
+        const { SKETCH } = ValueTypes;
+        const mockIsolateValues = {
+            hash: "someFileHash",
+            type: SKETCH,
+            result: "sketch_result"
+        };
+        mutations.setIsolateValue(state, mockIsolateValues);
+        expect(state.results.perIsolate.someFileHash).toStrictEqual({
+            hash: "someFileHash",
+            filename: "sampleName.fa",
+            sketch: "sketch_result"
+        });
     });
-    mutations.setClusters(state, { 0: { hash: 'someFileHash', cluster: '12' }, 1: { hash: 'someFileHash2', cluster: '2' } });
-    expect(state.results.perIsolate.someFileHash.cluster).toBe('12');
-  });
-  it('sets MicroreactURL', () => {
-    const state = mockRootState();
-    const mockURLInfo = {
-      cluster: '7',
-      url: 'microreact.org/mock',
-    };
-    mutations.addMicroreactURL(state, mockURLInfo);
-    expect(state.results.perCluster[mockURLInfo.cluster]).toStrictEqual({ cluster: '7', microreactURL: 'microreact.org/mock' });
-  });
-  it('sets Microreact Token', () => {
-    const state = mockRootState();
-    mutations.setToken(state, 'mock_microreact_token');
-    expect(state.microreactToken).toBe('mock_microreact_token');
-  });
-  it('sets graph', () => {
-    const state = mockRootState();
-    const mockGraphInfo = {
-      cluster: '7',
-      graph: '<graph></graph>',
-    };
-    mutations.addGraphml(state, mockGraphInfo);
-    expect(state.results.perCluster[mockGraphInfo.cluster]).toStrictEqual({ cluster: '7', graph: '<graph></graph>' });
-  });
-  it('sets project name', () => {
-    const state = mockRootState();
-    mutations.setProjectName(state, 'test name');
-    expect(state.projectName).toBe('test name');
-  });
+    it("sets AMR values", () => {
+        const state = mockRootState({
+            results: {
+                perIsolate: {
+                    someFileHash: {
+                        hash: "someFileHash",
+                        filename: "sampleName.fa"
+                    }
+                },
+                perCluster: {}
+            }
+        });
+        const { AMR } = ValueTypes;
+        const mockAMR = {
+            hash: "someFileHash",
+            type: AMR,
+            result: '{ "Penicillin": 0.5, "Chloramphenicol": 0.2 }'
+        };
+        mutations.setIsolateValue(state, mockAMR);
+        expect(state.results.perIsolate.someFileHash).toStrictEqual({
+            hash: "someFileHash",
+            filename: "sampleName.fa",
+            amr: { Penicillin: 0.5, Chloramphenicol: 0.2 }
+        });
+    });
+    it("sets submitStatus", () => {
+        const state = mockRootState();
+        mutations.setSubmitStatus(state, "submitted");
+        expect(state.submitStatus).toBe("submitted");
+    });
+    it("sets analysisStatus", () => {
+        const state = mockRootState();
+        const statusUpdate = {
+            assign: "finished",
+            microreact: "started",
+            network: "queued"
+        };
+        mutations.setAnalysisStatus(state, statusUpdate);
+        expect(state.analysisStatus).toBe(statusUpdate);
+    });
+    it("sets projectHash", () => {
+        const state = mockRootState();
+        const phash = "mock-hash";
+        mutations.setProjectHash(state, phash);
+        expect(state.projectHash).toBe(phash);
+    });
+    it("sets statusInterval", () => {
+        const state = mockRootState();
+        const interval = 122;
+        mutations.setStatusInterval(state, interval);
+        expect(state.statusInterval).toBe(interval);
+    });
+    it("sets cluster", () => {
+        const state = mockRootState({
+            results: {
+                perIsolate: {
+                    someFileHash: {
+                        hash: "someFileHash"
+                    },
+                    someFileHash2: {
+                        hash: "someFileHash2"
+                    }
+                },
+                perCluster: {}
+            }
+        });
+        mutations.setClusters(state, { 0: { hash: "someFileHash", cluster: "12" }, 1: { hash: "someFileHash2", cluster: "2" } });
+        expect(state.results.perIsolate.someFileHash.cluster).toBe("12");
+    });
+    it("sets MicroreactURL", () => {
+        const state = mockRootState();
+        const mockURLInfo = {
+            cluster: "7",
+            url: "microreact.org/mock"
+        };
+        mutations.addMicroreactURL(state, mockURLInfo);
+        expect(state.results.perCluster[mockURLInfo.cluster]).toStrictEqual({ cluster: "7", microreactURL: "microreact.org/mock" });
+    });
+    it("sets Microreact Token", () => {
+        const state = mockRootState();
+        mutations.setToken(state, "mock_microreact_token");
+        expect(state.microreactToken).toBe("mock_microreact_token");
+    });
+    it("sets graph", () => {
+        const state = mockRootState();
+        const mockGraphInfo = {
+            cluster: "7",
+            graph: "<graph></graph>"
+        };
+        mutations.addGraphml(state, mockGraphInfo);
+        expect(state.results.perCluster[mockGraphInfo.cluster]).toStrictEqual({ cluster: "7", graph: "<graph></graph>" });
+    });
+    it("sets project name", () => {
+        const state = mockRootState();
+        mutations.setProjectName(state, "test name");
+        expect(state.projectName).toBe("test name");
+    });
 });

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -32,7 +32,8 @@ describe("mutations", () => {
         const state = mockRootState();
         const mockFileMetadata = { hash: "someFileHash", name: "sampleName.fa" };
         mutations.addFile(state, mockFileMetadata);
-        expect(state.results.perIsolate.someFileHash).toStrictEqual({ hash: "someFileHash", filename: "sampleName.fa" });
+        expect(state.results.perIsolate.someFileHash)
+            .toStrictEqual({ hash: "someFileHash", filename: "sampleName.fa" });
     });
     it("sets sketch values", () => {
         const state = mockRootState({
@@ -125,7 +126,10 @@ describe("mutations", () => {
                 perCluster: {}
             }
         });
-        mutations.setClusters(state, { 0: { hash: "someFileHash", cluster: "12" }, 1: { hash: "someFileHash2", cluster: "2" } });
+        mutations.setClusters(
+            state,
+            { 0: { hash: "someFileHash", cluster: "12" }, 1: { hash: "someFileHash2", cluster: "2" } }
+        );
         expect(state.results.perIsolate.someFileHash.cluster).toBe("12");
     });
     it("sets MicroreactURL", () => {
@@ -135,7 +139,8 @@ describe("mutations", () => {
             url: "microreact.org/mock"
         };
         mutations.addMicroreactURL(state, mockURLInfo);
-        expect(state.results.perCluster[mockURLInfo.cluster]).toStrictEqual({ cluster: "7", microreactURL: "microreact.org/mock" });
+        expect(state.results.perCluster[mockURLInfo.cluster])
+            .toStrictEqual({ cluster: "7", microreactURL: "microreact.org/mock" });
     });
     it("sets Microreact Token", () => {
         const state = mockRootState();
@@ -149,7 +154,8 @@ describe("mutations", () => {
             graph: "<graph></graph>"
         };
         mutations.addGraphml(state, mockGraphInfo);
-        expect(state.results.perCluster[mockGraphInfo.cluster]).toStrictEqual({ cluster: "7", graph: "<graph></graph>" });
+        expect(state.results.perCluster[mockGraphInfo.cluster])
+            .toStrictEqual({ cluster: "7", graph: "<graph></graph>" });
     });
     it("sets project name", () => {
         const state = mockRootState();

--- a/app/client/tests/unit/utils.spec.ts
+++ b/app/client/tests/unit/utils.spec.ts
@@ -1,67 +1,67 @@
-import { addRowspan, getRGB, verbalProb } from '../../src/utils';
+import { addRowspan, getRGB, verbalProb } from "../../src/utils";
 
-describe('util functions', () => {
-  const sortedTable = [
-    { Hash: 'abcdefg', Cluster: 4 },
-    { Hash: 'hijklmn', Cluster: 7 },
-    { Hash: 'opqrstu', Cluster: 7 },
-    { Hash: 'vwxyz', Cluster: 12 },
-  ];
-  const tableRowspan = [
-    { Hash: 'abcdefg', Cluster: 4, Rowspan: 1 },
-    { Hash: 'hijklmn', Cluster: 7, Rowspan: 2 },
-    { Hash: 'opqrstu', Cluster: 7, Rowspan: 0 },
-    { Hash: 'vwxyz', Cluster: 12, Rowspan: 1 },
-  ];
+describe("util functions", () => {
+    const sortedTable = [
+        { Hash: "abcdefg", Cluster: 4 },
+        { Hash: "hijklmn", Cluster: 7 },
+        { Hash: "opqrstu", Cluster: 7 },
+        { Hash: "vwxyz", Cluster: 12 }
+    ];
+    const tableRowspan = [
+        { Hash: "abcdefg", Cluster: 4, Rowspan: 1 },
+        { Hash: "hijklmn", Cluster: 7, Rowspan: 2 },
+        { Hash: "opqrstu", Cluster: 7, Rowspan: 0 },
+        { Hash: "vwxyz", Cluster: 12, Rowspan: 1 }
+    ];
 
-  it('addRowspan adds correct rowspan to table array', () => {
-    const newTable = addRowspan(sortedTable);
-    expect(newTable).toEqual(tableRowspan);
-  });
+    it("addRowspan adds correct rowspan to table array", () => {
+        const newTable = addRowspan(sortedTable);
+        expect(newTable).toEqual(tableRowspan);
+    });
 
-  it('getRGB generates right RGB', () => {
+    it("getRGB generates right RGB", () => {
     // all extremes match target colours
-    expect(getRGB(0, 'Erythromycin')).toEqual('rgb(196,212,245)');
-    expect(getRGB(1, 'Erythromycin')).toEqual('rgb(2,57,168)');
-    expect(getRGB(0, 'Chloramphenicol')).toEqual('rgb(196,212,245)');
-    expect(getRGB(1, 'Chloramphenicol')).toEqual('rgb(2,57,168)');
-    expect(getRGB(0, 'Penicillin')).toEqual('rgb(196,212,245)');
-    expect(getRGB(1, 'Penicillin')).toEqual('rgb(2,57,168)');
-    // all Antibiotics match intermediate colour at 0.5
-    expect(getRGB(0.5, 'Erythromycin')).toEqual('rgb(99,135,207)');
-    expect(getRGB(0.5, 'Chloramphenicol')).toEqual('rgb(99,135,207)');
-    expect(getRGB(0.5, 'Penicillin')).toEqual('rgb(99,135,207)');
-    // some other values
-    expect(getRGB(0.2, 'Cotrim')).toEqual('rgb(118,150,214)');
-    expect(getRGB(0.4, 'Tetracycline')).toEqual('rgb(193,209,244)');
-    expect(getRGB(0.3, 'Erythromycin')).toEqual('rgb(138,166,222)');
-    // processing status is grey
-    expect(getRGB('processing', 'Erythromycin')).toEqual('rgb(50, 168, 82)');
-  });
+        expect(getRGB(0, "Erythromycin")).toEqual("rgb(196,212,245)");
+        expect(getRGB(1, "Erythromycin")).toEqual("rgb(2,57,168)");
+        expect(getRGB(0, "Chloramphenicol")).toEqual("rgb(196,212,245)");
+        expect(getRGB(1, "Chloramphenicol")).toEqual("rgb(2,57,168)");
+        expect(getRGB(0, "Penicillin")).toEqual("rgb(196,212,245)");
+        expect(getRGB(1, "Penicillin")).toEqual("rgb(2,57,168)");
+        // all Antibiotics match intermediate colour at 0.5
+        expect(getRGB(0.5, "Erythromycin")).toEqual("rgb(99,135,207)");
+        expect(getRGB(0.5, "Chloramphenicol")).toEqual("rgb(99,135,207)");
+        expect(getRGB(0.5, "Penicillin")).toEqual("rgb(99,135,207)");
+        // some other values
+        expect(getRGB(0.2, "Cotrim")).toEqual("rgb(118,150,214)");
+        expect(getRGB(0.4, "Tetracycline")).toEqual("rgb(193,209,244)");
+        expect(getRGB(0.3, "Erythromycin")).toEqual("rgb(138,166,222)");
+        // processing status is grey
+        expect(getRGB("processing", "Erythromycin")).toEqual("rgb(50, 168, 82)");
+    });
 
-  it('verbalProb generates right verbal representation of probability', () => {
-    expect(verbalProb(1, 'Penicillin')).toEqual('Highly likely');
-    expect(verbalProb(0.8, 'Penicillin')).toEqual('Very good chance');
-    expect(verbalProb(0.6, 'Penicillin')).toEqual('Probably');
-    expect(verbalProb(0.45, 'Penicillin')).toEqual('Probably not');
-    expect(verbalProb(0.3, 'Penicillin')).toEqual('Unlikely');
-    expect(verbalProb(0.1, 'Penicillin')).toEqual('Highly unlikely');
+    it("verbalProb generates right verbal representation of probability", () => {
+        expect(verbalProb(1, "Penicillin")).toEqual("Highly likely");
+        expect(verbalProb(0.8, "Penicillin")).toEqual("Very good chance");
+        expect(verbalProb(0.6, "Penicillin")).toEqual("Probably");
+        expect(verbalProb(0.45, "Penicillin")).toEqual("Probably not");
+        expect(verbalProb(0.3, "Penicillin")).toEqual("Unlikely");
+        expect(verbalProb(0.1, "Penicillin")).toEqual("Highly unlikely");
 
-    expect(verbalProb(0.8, 'Chloramphenicol')).toEqual('Probably');
-    expect(verbalProb(0.54, 'Chloramphenicol')).toEqual('Unsure');
-    expect(verbalProb(0.3, 'Chloramphenicol')).toEqual('Highly unlikely');
+        expect(verbalProb(0.8, "Chloramphenicol")).toEqual("Probably");
+        expect(verbalProb(0.54, "Chloramphenicol")).toEqual("Unsure");
+        expect(verbalProb(0.3, "Chloramphenicol")).toEqual("Highly unlikely");
 
-    expect(verbalProb(0.8, 'Erythromycin')).toEqual('Almost certainly');
-    expect(verbalProb(0.4, 'Erythromycin')).toEqual('Probably not');
-    expect(verbalProb(0.1, 'Erythromycin')).toEqual('Highly unlikely');
+        expect(verbalProb(0.8, "Erythromycin")).toEqual("Almost certainly");
+        expect(verbalProb(0.4, "Erythromycin")).toEqual("Probably not");
+        expect(verbalProb(0.1, "Erythromycin")).toEqual("Highly unlikely");
 
-    expect(verbalProb(0.6, 'Tetracycline')).toEqual('Almost certainly');
-    expect(verbalProb(0.4, 'Tetracycline')).toEqual('Highly unlikely');
+        expect(verbalProb(0.6, "Tetracycline")).toEqual("Almost certainly");
+        expect(verbalProb(0.4, "Tetracycline")).toEqual("Highly unlikely");
 
-    expect(verbalProb(0.9, 'Cotrim')).toEqual('Almost certainly');
-    expect(verbalProb(0.75, 'Cotrim')).toEqual('Highly likely');
-    expect(verbalProb(0.6, 'Cotrim')).toEqual('Very good chance');
-    expect(verbalProb(0.4, 'Cotrim')).toEqual('Probably not');
-    expect(verbalProb(0.1, 'Cotrim')).toEqual('Unlikely');
-  });
+        expect(verbalProb(0.9, "Cotrim")).toEqual("Almost certainly");
+        expect(verbalProb(0.75, "Cotrim")).toEqual("Highly likely");
+        expect(verbalProb(0.6, "Cotrim")).toEqual("Very good chance");
+        expect(verbalProb(0.4, "Cotrim")).toEqual("Probably not");
+        expect(verbalProb(0.1, "Cotrim")).toEqual("Unlikely");
+    });
 });

--- a/app/client/tests/unit/views/AboutView.spec.ts
+++ b/app/client/tests/unit/views/AboutView.spec.ts
@@ -1,47 +1,47 @@
-import { mount } from '@vue/test-utils';
-import AboutView from '@/views/AboutView.vue';
-import { createStore } from 'vuex';
+import { mount } from "@vue/test-utils";
+import AboutView from "@/views/AboutView.vue";
+import { createStore } from "vuex";
 
-describe('About', () => {
-  const getVersions = jest.fn();
+describe("About", () => {
+    const getVersions = jest.fn();
 
-  const store = createStore({
-    state() {
-      return {
-        versions: [
-          { name: 'beebop', version: '0.1.0' },
-          { name: 'poppunk', version: '2.4.0' },
-        ],
-      };
-    },
-    actions: {
-      getVersions,
-    },
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('renders VersionInfo', () => {
-    const wrapper = mount(AboutView, {
-      global: {
-        plugins: [store],
-      },
+    const store = createStore({
+        state() {
+            return {
+                versions: [
+                    { name: "beebop", version: "0.1.0" },
+                    { name: "poppunk", version: "2.4.0" }
+                ]
+            };
+        },
+        actions: {
+            getVersions
+        }
     });
-    expect(wrapper.find('h2').text()).toMatch('About');
-    const versions = wrapper.findAll('.version-info');
-    expect(versions.length).toBe(2);
-    expect(versions[0].text()).toBe('beebop 0.1.0');
-    expect(versions[1].text()).toBe('poppunk 2.4.0');
-  });
 
-  it('calls getVersion', () => {
-    mount(AboutView, {
-      global: {
-        plugins: [store],
-      },
+    beforeEach(() => {
+        jest.resetAllMocks();
     });
-    expect(getVersions).toHaveBeenCalled();
-  });
+
+    it("renders VersionInfo", () => {
+        const wrapper = mount(AboutView, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(wrapper.find("h2").text()).toMatch("About");
+        const versions = wrapper.findAll(".version-info");
+        expect(versions.length).toBe(2);
+        expect(versions[0].text()).toBe("beebop 0.1.0");
+        expect(versions[1].text()).toBe("poppunk 2.4.0");
+    });
+
+    it("calls getVersion", () => {
+        mount(AboutView, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(getVersions).toHaveBeenCalled();
+    });
 });

--- a/app/client/tests/unit/views/HomeView.spec.ts
+++ b/app/client/tests/unit/views/HomeView.spec.ts
@@ -1,77 +1,77 @@
-import { mount } from '@vue/test-utils';
-import HomeView from '@/views/HomeView.vue';
-import Vuex from 'vuex';
-import { RootState } from '@/store/state';
-import { mockRootState } from '../../mocks';
+import { mount } from "@vue/test-utils";
+import HomeView from "@/views/HomeView.vue";
+import Vuex from "vuex";
+import { RootState } from "@/store/state";
+import { mockRootState } from "../../mocks";
 
-describe('Home', () => {
-  const getUser = jest.fn();
+describe("Home", () => {
+    const getUser = jest.fn();
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
 
-  it('calls getUser', () => {
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        user: null,
-      }),
-      actions: {
-        getUser,
-      },
+    it("calls getUser", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                user: null
+            }),
+            actions: {
+                getUser
+            }
+        });
+        mount(HomeView, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(getUser).toHaveBeenCalled();
     });
-    mount(HomeView, {
-      global: {
-        plugins: [store],
-      },
-    });
-    expect(getUser).toHaveBeenCalled();
-  });
 
-  it('shows login buttons when not logged in', () => {
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        user: null,
-      }),
-      actions: {
-        getUser,
-      },
+    it("shows login buttons when not logged in", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                user: null
+            }),
+            actions: {
+                getUser
+            }
+        });
+        const wrapper = mount(HomeView, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(wrapper.find("h1").text()).toMatch("Welcome to beebop!");
+        const socialButtons = wrapper.findAll(".btn-social");
+        expect(socialButtons.length).toBe(2);
+        expect(socialButtons[0].text()).toBe("Login with Google");
+        expect(socialButtons[1].text()).toBe("Login with Github");
     });
-    const wrapper = mount(HomeView, {
-      global: {
-        plugins: [store],
-      },
-    });
-    expect(wrapper.find('h1').text()).toMatch('Welcome to beebop!');
-    const socialButtons = wrapper.findAll('.btn-social');
-    expect(socialButtons.length).toBe(2);
-    expect(socialButtons[0].text()).toBe('Login with Google');
-    expect(socialButtons[1].text()).toBe('Login with Github');
-  });
 
-  it('shows create project controls when logged in', () => {
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        user: {
-          name: 'Jane',
-          id: '543653d45',
-          provider: 'google',
-        },
-        results: {
-          perIsolate: {},
-          perCluster: {},
-        },
-      }),
-      actions: {
-        getUser,
-      },
+    it("shows create project controls when logged in", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                user: {
+                    name: "Jane",
+                    id: "543653d45",
+                    provider: "google"
+                },
+                results: {
+                    perIsolate: {},
+                    perCluster: {}
+                }
+            }),
+            actions: {
+                getUser
+            }
+        });
+        const wrapper = mount(HomeView, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(wrapper.find("input#create-project-name").exists()).toBe(true);
+        expect(wrapper.find("button#create-project-btn").exists()).toBe(true);
     });
-    const wrapper = mount(HomeView, {
-      global: {
-        plugins: [store],
-      },
-    });
-    expect(wrapper.find('input#create-project-name').exists()).toBe(true);
-    expect(wrapper.find('button#create-project-btn').exists()).toBe(true);
-  });
 });

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -1,177 +1,177 @@
-import { mount, shallowMount } from '@vue/test-utils';
-import ProjectView from '@/views/ProjectView.vue';
-import Vuex from 'vuex';
-import { RootState } from '@/store/state';
-import { mockRootState } from '../../mocks';
+import { mount, shallowMount } from "@vue/test-utils";
+import ProjectView from "@/views/ProjectView.vue";
+import Vuex from "vuex";
+import { RootState } from "@/store/state";
+import { mockRootState } from "../../mocks";
 
-describe('Project', () => {
-  const getUser = jest.fn();
-  const mockRouter = {
-    push: jest.fn(),
-  };
+describe("Project", () => {
+    const getUser = jest.fn();
+    const mockRouter = {
+        push: jest.fn()
+    };
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('displays as expected, gets user information on mount', () => {
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        projectName: 'test project',
-        user: {
-          name: 'Jane',
-          id: '543653d45',
-          provider: 'google',
-        },
-      }),
-      actions: {
-        getUser,
-      },
-    });
-    const wrapper = mount(ProjectView, {
-      global: {
-        plugins: [store],
-        mocks: {
-          $router: mockRouter,
-        },
-      },
+    beforeEach(() => {
+        jest.resetAllMocks();
     });
 
-    expect(wrapper.find('h2').text()).toBe('Project: test project');
-    expect(wrapper.findAll('.dropzone-component').length).toBe(1);
-    const buttons = wrapper.findAll('.btn-standard');
-    expect(buttons.length).toBe(1);
-    expect(buttons[0].text()).toBe('Start Analysis');
-    expect(wrapper.find('div#no-results').text()).toBe('No data uploaded yet');
-    expect(getUser).toHaveBeenCalled();
-    expect(mockRouter.push).not.toHaveBeenCalled();
-  });
+    it("displays as expected, gets user information on mount", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                projectName: "test project",
+                user: {
+                    name: "Jane",
+                    id: "543653d45",
+                    provider: "google"
+                }
+            }),
+            actions: {
+                getUser
+            }
+        });
+        const wrapper = mount(ProjectView, {
+            global: {
+                plugins: [store],
+                mocks: {
+                    $router: mockRouter
+                }
+            }
+        });
 
-  it('after submission  dropzone disappears, now has progress bar and table and network tabs + panes ', () => {
-    const uniqueClusters = jest.fn().mockReturnValue([3, 7]);
-
-    const analysisProgress = jest.fn().mockReturnValue({
-      finished: 1,
-      progress: 0.3333333333333333,
-      total: 3,
+        expect(wrapper.find("h2").text()).toBe("Project: test project");
+        expect(wrapper.findAll(".dropzone-component").length).toBe(1);
+        const buttons = wrapper.findAll(".btn-standard");
+        expect(buttons.length).toBe(1);
+        expect(buttons[0].text()).toBe("Start Analysis");
+        expect(wrapper.find("div#no-results").text()).toBe("No data uploaded yet");
+        expect(getUser).toHaveBeenCalled();
+        expect(mockRouter.push).not.toHaveBeenCalled();
     });
 
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        projectName: "testProject",
-        user: {
-          name: 'Jane',
-          id: '543653d45',
-          provider: 'google',
-        },
-        submitStatus: 'submitted',
-        analysisStatus: {
-          assign: 'finished',
-          microreact: 'finished',
-          network: 'finished',
-        },
-        results: {
-          perIsolate: {
-            hash1: {
-              hash: 'hash1',
-              filename: 'example1.fa',
-              sketch: 'sketch',
-              cluster: 7,
-              amr: {
-                filename: 'example1.fa',
-                Penicillin: 0.892,
-                Chloramphenicol: 0.39,
-                Erythromycin: 0.151,
-                Tetracycline: 0.453,
-                Trim_sulfa: 0.974,
-              },
+    it("after submission  dropzone disappears, now has progress bar and table and network tabs + panes ", () => {
+        const uniqueClusters = jest.fn().mockReturnValue([3, 7]);
+
+        const analysisProgress = jest.fn().mockReturnValue({
+            finished: 1,
+            progress: 0.3333333333333333,
+            total: 3
+        });
+
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                projectName: "testProject",
+                user: {
+                    name: "Jane",
+                    id: "543653d45",
+                    provider: "google"
+                },
+                submitStatus: "submitted",
+                analysisStatus: {
+                    assign: "finished",
+                    microreact: "finished",
+                    network: "finished"
+                },
+                results: {
+                    perIsolate: {
+                        hash1: {
+                            hash: "hash1",
+                            filename: "example1.fa",
+                            sketch: "sketch",
+                            cluster: 7,
+                            amr: {
+                                filename: "example1.fa",
+                                Penicillin: 0.892,
+                                Chloramphenicol: 0.39,
+                                Erythromycin: 0.151,
+                                Tetracycline: 0.453,
+                                Trim_sulfa: 0.974
+                            }
+                        },
+                        hash2: {
+                            hash: "hash2",
+                            filename: "example2.fa",
+                            sketch: "sketch",
+                            cluster: 3,
+                            amr: {
+                                filename: "example2.fa",
+                                Penicillin: 0.892,
+                                Chloramphenicol: 0.39,
+                                Erythromycin: 0.151,
+                                Tetracycline: 0.453,
+                                Trim_sulfa: 0.974
+                            }
+                        },
+                        hash3: {
+                            hash: "hash3",
+                            filename: "example3.fa",
+                            sketch: "sketch",
+                            cluster: 7,
+                            amr: {
+                                filename: "example3.fa",
+                                Penicillin: 0.892,
+                                Chloramphenicol: 0.39,
+                                Erythromycin: 0.151,
+                                Tetracycline: 0.453,
+                                Trim_sulfa: 0.974
+                            }
+                        }
+                    },
+                    perCluster: {}
+                }
+            }),
+            actions: {
+                getUser
             },
-            hash2: {
-              hash: 'hash2',
-              filename: 'example2.fa',
-              sketch: 'sketch',
-              cluster: 3,
-              amr: {
-                filename: 'example2.fa',
-                Penicillin: 0.892,
-                Chloramphenicol: 0.39,
-                Erythromycin: 0.151,
-                Tetracycline: 0.453,
-                Trim_sulfa: 0.974,
-              },
+            getters: {
+                analysisProgress,
+                uniqueClusters
+            }
+        });
+        const wrapper = shallowMount(ProjectView, {
+            global: {
+                plugins: [store]
             },
-            hash3: {
-              hash: 'hash3',
-              filename: 'example3.fa',
-              sketch: 'sketch',
-              cluster: 7,
-              amr: {
-                filename: 'example3.fa',
-                Penicillin: 0.892,
-                Chloramphenicol: 0.39,
-                Erythromycin: 0.151,
-                Tetracycline: 0.453,
-                Trim_sulfa: 0.974,
-              },
-            },
-          },
-          perCluster: {},
-        },
-      }),
-      actions: {
-        getUser,
-      },
-      getters: {
-        analysisProgress,
-        uniqueClusters,
-      },
-    });
-    const wrapper = shallowMount(ProjectView, {
-      global: {
-        plugins: [store],
-      },
-      stubs: {
-        NetworkVisualisations: '<div>Network Visualisations</div>',
-      },
+            stubs: {
+                NetworkVisualisations: "<div>Network Visualisations</div>"
+            }
+        });
+
+        expect(wrapper.findAll(".dropzone-component").length).toBe(0);
+        expect(wrapper.findAll(".progress-bar-component").length).toBe(1);
+        const tabs = wrapper.findAll(".nav-link");
+        expect(tabs.length).toBe(2);
+        expect(tabs[0].text()).toBe("Table");
+        expect(tabs[1].text()).toBe("Network");
+        expect(wrapper.findAll(".tab-pane").length).toBe(2);
+        expect(wrapper.vm.selectedTab).toBe("table");
+        tabs[1].trigger("click");
+        expect(wrapper.vm.selectedTab).toBe("network");
     });
 
-    expect(wrapper.findAll('.dropzone-component').length).toBe(0);
-    expect(wrapper.findAll('.progress-bar-component').length).toBe(1);
-    const tabs = wrapper.findAll('.nav-link');
-    expect(tabs.length).toBe(2);
-    expect(tabs[0].text()).toBe('Table');
-    expect(tabs[1].text()).toBe('Network');
-    expect(wrapper.findAll('.tab-pane').length).toBe(2);
-    expect(wrapper.vm.selectedTab).toBe('table');
-    tabs[1].trigger('click');
-    expect(wrapper.vm.selectedTab).toBe('network');
-  });
+    it("redirects to root if no project name", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                projectName: null,
+                user: {
+                    name: "Jane",
+                    id: "543653d45",
+                    provider: "google"
+                }
+            }),
+            actions: {
+                getUser
+            }
+        });
+        mount(ProjectView, {
+            global: {
+                plugins: [store],
+                mocks: {
+                    $router: mockRouter
+                }
+            }
+        });
 
-  it('redirects to root if no project name', () => {
-    const store = new Vuex.Store<RootState>({
-      state: mockRootState({
-        projectName: null,
-        user: {
-          name: 'Jane',
-          id: '543653d45',
-          provider: 'google',
-        },
-      }),
-      actions: {
-        getUser,
-      },
+        expect(getUser).not.toHaveBeenCalled();
+        expect(mockRouter.push).toHaveBeenCalledTimes(1);
+        expect(mockRouter.push.mock.calls[0][0]).toBe("/");
     });
-    mount(ProjectView, {
-      global: {
-        plugins: [store],
-        mocks: {
-          $router: mockRouter,
-        },
-      },
-    });
-
-    expect(getUser).not.toHaveBeenCalled();
-    expect(mockRouter.push).toHaveBeenCalledTimes(1);
-    expect(mockRouter.push.mock.calls[0][0]).toBe('/');
-  });
 });

--- a/app/client/tests/unit/wasmMocks.ts
+++ b/app/client/tests/unit/wasmMocks.ts
@@ -1,25 +1,25 @@
 export const moduleMock = {
-  workdir: '',
-  data: {},
-  fs: '',
-  FS: {
-    mkdir(dirname: string) {
-      moduleMock.workdir = dirname;
+    workdir: "",
+    data: {},
+    fs: "",
+    FS: {
+        mkdir(dirname: string) {
+            moduleMock.workdir = dirname;
+        },
+        mount(fs: string, filedata: any, dirname: string) {
+            moduleMock.data = { filedata, dir: dirname };
+            moduleMock.fs = fs;
+        },
+        filesystems: {
+            WORKERFS: "fs"
+        }
     },
-    mount(fs: string, filedata: any, dirname: string) {
-      moduleMock.data = { filedata, dir: dirname };
-      moduleMock.fs = fs;
+    make_prediction_json(path: string) {
+        return path;
     },
-    filesystems: {
-      WORKERFS: 'fs',
-    },
-  },
-  make_prediction_json(path: string) {
-    return path;
-  },
-  sketch(
-    path: string,
-    /* eslint-disable */
+    sketch(
+        path: string,
+        /* eslint-disable */
     int1: number,
     int2: number,
     int3: number,
@@ -28,17 +28,17 @@ export const moduleMock = {
     bool1: boolean,
     bool2: boolean,
     /* eslint-enable */
-  ) {
-    return path;
-  },
+    ) {
+        return path;
+    }
 };
 
 // AMRprediction
 export function AMRprediction() {
-  return Promise.resolve(moduleMock);
+    return Promise.resolve(moduleMock);
 }
 
 // WebSketch
 export function WebSketch() {
-  return Promise.resolve(moduleMock);
+    return Promise.resolve(moduleMock);
 }

--- a/app/client/tests/unit/worker.spec.ts
+++ b/app/client/tests/unit/worker.spec.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import vm from 'vm';
-import { moduleMock, AMRprediction, WebSketch } from './wasmMocks';
+import fs from "fs";
+import vm from "vm";
+import { moduleMock, AMRprediction, WebSketch } from "./wasmMocks";
 
-const data = fs.readFileSync('./public/worker.js', { encoding: 'utf8' });
+const data = fs.readFileSync("./public/worker.js", { encoding: "utf8" });
 const script = new vm.Script(data);
 interface Others {
   log: any,
@@ -12,46 +12,46 @@ interface Others {
 }
 
 const worker: Partial<Worker> & Others = {
-  onmessage: () => {},
-  postMessage: jest.fn(),
+    onmessage: () => {},
+    postMessage: jest.fn(),
   log: console.log,  // eslint-disable-line
-  moduleMock,
-  AMRprediction,
-  WebSketch,
+    moduleMock,
+    AMRprediction,
+    WebSketch
 };
 script.runInNewContext(worker);
 
-describe('Worker', () => {
-  const message = {
-    data: { hash: 'abc123', fileObject: { name: 'mockfile.fa' } },
-  };
+describe("Worker", () => {
+    const message = {
+        data: { hash: "abc123", fileObject: { name: "mockfile.fa" } }
+    };
 
-  (worker.onmessage as any)(message);
+    (worker.onmessage as any)(message);
 
-  it('creates working dir in FS', (done) => {
-    setTimeout(() => {
-      expect(worker.moduleMock.workdir).toBe('/working');
-      done();
+    it("creates working dir in FS", (done) => {
+        setTimeout(() => {
+            expect(worker.moduleMock.workdir).toBe("/working");
+            done();
+        });
     });
-  });
 
-  it('puts file into workdir of FS', (done) => {
-    setTimeout(() => {
-      expect(worker.moduleMock.data.filedata).toEqual({ files: [message.data.fileObject] });
-      expect(worker.moduleMock.data.dir).toBe(worker.moduleMock.workdir);
-      done();
+    it("puts file into workdir of FS", (done) => {
+        setTimeout(() => {
+            expect(worker.moduleMock.data.filedata).toEqual({ files: [message.data.fileObject] });
+            expect(worker.moduleMock.data.dir).toBe(worker.moduleMock.workdir);
+            done();
+        });
     });
-  });
 
-  it('sends results back', (done) => {
-    setTimeout(() => {
-      expect(worker.postMessage).toHaveBeenCalledWith(
-        { hash: 'abc123', type: 'amr', result: '/working/mockfile.fa' },
-      );
-      expect(worker.postMessage).toHaveBeenCalledWith(
-        { hash: 'abc123', type: 'sketch', result: '/working/mockfile.fa' },
-      );
-      done();
+    it("sends results back", (done) => {
+        setTimeout(() => {
+            expect(worker.postMessage).toHaveBeenCalledWith(
+                { hash: "abc123", type: "amr", result: "/working/mockfile.fa" }
+            );
+            expect(worker.postMessage).toHaveBeenCalledWith(
+                { hash: "abc123", type: "sketch", result: "/working/mockfile.fa" }
+            );
+            done();
+        });
     });
-  });
 });

--- a/app/client/vue.config.js
+++ b/app/client/vue.config.js
@@ -1,21 +1,21 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { defineConfig } = require('@vue/cli-service');
+const { defineConfig } = require("@vue/cli-service");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const path = require('path');
+const path = require("path");
 
 module.exports = defineConfig({
-  transpileDependencies: true,
-  css: {
-    extract: false,
-  },
-  chainWebpack: (config) => {
-    config
-      .resolve
-      .alias
-      .set('@settings', path.resolve(
-        __dirname,
-        'src/settings/',
-        process.env.BUILD_TARGET || 'development',
-      ));
-  },
+    transpileDependencies: true,
+    css: {
+        extract: false
+    },
+    chainWebpack: (config) => {
+        config
+            .resolve
+            .alias
+            .set("@settings", path.resolve(
+                __dirname,
+                "src/settings/",
+                process.env.BUILD_TARGET || "development"
+            ));
+    }
 });


### PR DESCRIPTION
This branch adds our standard set of front end eslint rules to beebop's client package, in order to be consistent with our other applications. It uses an identical `eslintrc.js` to that used in wodin. The code has been updated to conform to these rules. The main changes are:
- indentation of 4 spaces rather than 2
- double quotes for string literals rather than single
- max line length of 120
- no dangling commas after the final prop in objects

Sorry, it's a big changeset, but all the changes are simple!