### PR TITLE
bacpop-78 Display names of user's previous projects

### DIFF
--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -38,7 +38,7 @@ jobs:
       env:
         MICROREACT_TOKEN: ${{ secrets.MICROREACT_TOKEN }}
       working-directory: ./app/client
-      run: npx playwright test
+      run: npx playwright test --reporter=github
     - name: Stop all components
       working-directory: .
       run: ./scripts/stop_test

--- a/app/client/src/components/SavedProjects.vue
+++ b/app/client/src/components/SavedProjects.vue
@@ -1,16 +1,24 @@
-<template v-if="savedProjects.length">
-  <h3>Load a previously saved project</h3>
-  <div class="container">
-      <div class="row">
-        <div class="col-6">ProjectName</div>
-      </div>
-      <div v-for="project in savedProjects" :key="project.hash" class="row">
-          <div class="col-6">{{ project.name }}</div>
+<template>
+  <div v-if="savedProjects.length" class="ms-2">
+      <h4 class="mt-5">Load a previously saved project</h4>
+      <div class="container">
+          <div class="row fw-bold">
+            <div class="col-6">Project name</div>
+          </div>
+          <hr/>
+          <div v-for="project in savedProjects" :key="project.hash" class="row">
+              <div class="col-6">
+                  <span class="clickable brand-text">{{ project.name }}</span>
+              </div>
+          </div>
       </div>
   </div>
 </template>
 
 <script>
+
+import { mapActions, mapState } from "vuex";
+
 export default {
     name: "SavedProjects",
     methods: {
@@ -20,8 +28,7 @@ export default {
         ...mapState(["savedProjects"])
     },
     mounted() {
-        getSavedProjects();
+        this.getSavedProjects();
     }
-}
+};
 </script>
-

--- a/app/client/src/components/SavedProjects.vue
+++ b/app/client/src/components/SavedProjects.vue
@@ -1,5 +1,13 @@
 <template v-if="savedProjects.length">
   <h3>Load a previously saved project</h3>
+  <div class="container">
+      <div class="row">
+        <div class="col-6">ProjectName</div>
+      </div>
+      <div v-for="project in savedProjects" :key="project.hash" class="row">
+          <div class="col-6">{{ project.name }}</div>
+      </div>
+  </div>
 </template>
 
 <script>

--- a/app/client/src/components/SavedProjects.vue
+++ b/app/client/src/components/SavedProjects.vue
@@ -2,11 +2,11 @@
   <div v-if="savedProjects.length" class="ms-2">
       <h4 class="mt-5">Load a previously saved project</h4>
       <div class="container">
-          <div class="row fw-bold">
+          <div class="row fw-bold saved-project-headers">
             <div class="col-6">Project name</div>
           </div>
           <hr/>
-          <div v-for="project in savedProjects" :key="project.hash" class="row">
+          <div v-for="project in savedProjects" :key="project.hash" class="row saved-project-row">
               <div class="col-6">
                   <span class="clickable brand-text">{{ project.name }}</span>
               </div>

--- a/app/client/src/components/SavedProjects.vue
+++ b/app/client/src/components/SavedProjects.vue
@@ -1,0 +1,19 @@
+<template v-if="savedProjects.length">
+  <h3>Load a previously saved project</h3>
+</template>
+
+<script>
+export default {
+    name: "SavedProjects",
+    methods: {
+        ...mapActions(["getSavedProjects"])
+    },
+    computed: {
+        ...mapState(["savedProjects"])
+    },
+    mounted() {
+        getSavedProjects();
+    }
+}
+</script>
+

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -26,7 +26,7 @@
 
 <script lang='ts'>
 import { defineComponent } from "vue";
-import { mapActions, mapMutations, mapState } from "vuex";
+import { mapActions, mapState } from "vuex";
 import SavedProjects from "@/components/SavedProjects.vue";
 
 export default defineComponent({
@@ -46,11 +46,10 @@ export default defineComponent({
         ...mapState(["user"])
     },
     methods: {
-        ...mapActions(["getUser"]),
-        ...mapMutations(["setProjectName"]),
+        ...mapActions(["getUser", "newProject"]),
         runAnalysis() {
             if (this.projectName) {
-                this.setProjectName(this.projectName);
+                this.newProject(this.projectName);
                 this.$router.push("/project");
             }
         }

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-3 container left">
+  <div v-if="user" class="mt-3 container left">
     <div class="row">
       <div class="col-6">
         <input id="create-project-name"
@@ -18,15 +18,22 @@
         @click="runAnalysis">Create new project</button>
       </div>
     </div>
+    <div class="row">
+        <saved-projects></saved-projects>
+    </div>
   </div>
 </template>
 
 <script lang='ts'>
 import { defineComponent } from "vue";
-import { mapActions, mapMutations } from "vuex";
+import {mapActions, mapMutations, mapState} from "vuex";
+import SavedProjects from "@/components/SavedProjects.vue";
 
 export default defineComponent({
     name: "SelectAction",
+    components: {
+        SavedProjects
+    },
     data() {
         return {
             projectName: ""
@@ -34,6 +41,9 @@ export default defineComponent({
     },
     mounted() {
         this.getUser();
+    },
+    computed: {
+        ...mapState(["user"])
     },
     methods: {
         ...mapActions(["getUser"]),

--- a/app/client/src/components/SelectAction.vue
+++ b/app/client/src/components/SelectAction.vue
@@ -26,7 +26,7 @@
 
 <script lang='ts'>
 import { defineComponent } from "vue";
-import {mapActions, mapMutations, mapState} from "vuex";
+import { mapActions, mapMutations, mapState } from "vuex";
 import SavedProjects from "@/components/SavedProjects.vue";
 
 export default defineComponent({

--- a/app/client/src/scss/myStyles.scss
+++ b/app/client/src/scss/myStyles.scss
@@ -1,3 +1,5 @@
+$brand: #42b983;
+
 .collapsedCol {
     visibility: 'collapse';
 }
@@ -61,7 +63,7 @@
 
 .btn-standard {
     color: #fff;
-    background-color: #42b983;
+    background-color: $brand;
     border-color: rgba(0, 0, 0, 0.2);
     padding: 0px 12px;
     margin: 6px;
@@ -126,7 +128,7 @@
 }
 
 .progress-bar {
-    background-color: #42b983;
+    background-color: $brand;
 }
 
 .checkmark {
@@ -301,4 +303,12 @@ th {
 
 .icon {
     vertical-align: middle;
+}
+
+.brand-text {
+    color: $brand;
+}
+
+.clickable {
+    cursor: pointer;
 }

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -4,7 +4,7 @@ import config from "@settings/config";
 import { Md5 } from "ts-md5/dist/md5";
 import { RootState } from "@/store/state";
 import {
-    Versions, User, AnalysisStatus, ClusterInfo, Dict
+    Versions, User, AnalysisStatus, ClusterInfo, Dict, SavedProject
 } from "@/types";
 import { api } from "@/apiService";
 
@@ -23,6 +23,12 @@ export default {
             .withSuccess("setUser")
             .withError("addError")
             .get<User>(`${serverUrl}/user`);
+    },
+    async getSavedProjects(context: ActionContext<RootState, RootState>) {
+        await api(context)
+            .withSuccess("setSavedProjects")
+            .withError("addError")
+            .get<SavedProject[]>(`${serverUrl}/projects`);
     },
     async logoutUser() {
         await axios.get(`${serverUrl}/logout`);

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -24,6 +24,15 @@ export default {
             .withError("addError")
             .get<User>(`${serverUrl}/user`);
     },
+    async newProject(context: ActionContext<RootState, RootState>, name: string) {
+        const { state, commit } = context;
+        commit("setProjectName", name);
+        // TODO: request type
+        await api(context)
+            .withSuccess("setProjectId")
+            .withError("addError")
+            .post<any>(`${serverUrl}/project`, { name: state.projectName });
+    },
     async getSavedProjects(context: ActionContext<RootState, RootState>) {
         await api(context)
             .withSuccess("setSavedProjects")
@@ -79,7 +88,7 @@ export default {
             .ignoreSuccess()
             .post<AnalysisStatus>(`${serverUrl}/poppunk`, {
                 projectHash: phash,
-                projectName: state.projectName,
+                projectId: state.projectId,
                 sketches: jsonSketches,
                 names: filenameMapping
             });

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -4,7 +4,7 @@ import config from "@settings/config";
 import { Md5 } from "ts-md5/dist/md5";
 import { RootState } from "@/store/state";
 import {
-    Versions, User, AnalysisStatus, ClusterInfo, Dict, SavedProject
+    Versions, User, AnalysisStatus, ClusterInfo, Dict, SavedProject, NewProjectRequest
 } from "@/types";
 import { api } from "@/apiService";
 
@@ -25,13 +25,12 @@ export default {
             .get<User>(`${serverUrl}/user`);
     },
     async newProject(context: ActionContext<RootState, RootState>, name: string) {
-        const { state, commit } = context;
+        const { commit } = context;
         commit("setProjectName", name);
-        // TODO: request type
         await api(context)
             .withSuccess("setProjectId")
             .withError("addError")
-            .post<any>(`${serverUrl}/project`, { name: state.projectName });
+            .post<NewProjectRequest>(`${serverUrl}/project`, { name });
     },
     async getSavedProjects(context: ActionContext<RootState, RootState>) {
         await api(context)

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -14,8 +14,9 @@ export default new Vuex.Store<RootState>({
             perIsolate: {},
             perCluster: {}
         },
-        projectHash: null,
         projectName: null,
+        projectId: null,
+        projectHash: null,
         submitStatus: null,
         analysisStatus: {
             assign: null,

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -22,7 +22,8 @@ export default new Vuex.Store<RootState>({
             microreact: null,
             network: null
         },
-        statusInterval: undefined
+        statusInterval: undefined,
+        savedProjects: []
     },
     getters,
     mutations,

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -10,6 +10,9 @@ export default {
     setProjectName(state: RootState, projectName: string) {
         state.projectName = projectName;
     },
+    setProjectId(state: RootState, projectId: string) {
+        state.projectId = projectId;
+    },
     setVersions(state: RootState, versioninfo: Versions) {
         state.versions = versioninfo;
     },

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -69,6 +69,7 @@ export default {
         };
     },
     setSavedProjects(state: RootState, savedProjects: SavedProject[]) {
+        console.log(`setting saved projects: ${JSON.stringify(savedProjects)}`);
         state.savedProjects = savedProjects;
     }
 };

--- a/app/client/src/store/mutations.ts
+++ b/app/client/src/store/mutations.ts
@@ -1,6 +1,6 @@
 import { RootState } from "@/store/state";
 import {
-    Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError
+    Versions, User, IsolateValue, AnalysisStatus, ClusterInfo, BeebopError, SavedProject
 } from "@/types";
 
 export default {
@@ -67,5 +67,8 @@ export default {
             cluster: graphInfo.cluster,
             graph: graphInfo.graph
         };
+    },
+    setSavedProjects(state: RootState, savedProjects: SavedProject[]) {
+        state.savedProjects = savedProjects;
     }
 };

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -3,7 +3,7 @@ import {
     Versions,
     User,
     Results,
-    AnalysisStatus
+    AnalysisStatus, SavedProject
 } from "@/types";
 
 export interface RootState {
@@ -17,4 +17,5 @@ export interface RootState {
   projectHash: string | null
   projectName: string | null
   statusInterval: number | undefined
+  savedProjects: SavedProject[]
 }

--- a/app/client/src/store/state.ts
+++ b/app/client/src/store/state.ts
@@ -14,8 +14,9 @@ export interface RootState {
   results: Results
   submitStatus: string | null
   analysisStatus: AnalysisStatus
-  projectHash: string | null
   projectName: string | null
+  projectId: string | null
+  projectHash: string | null
   statusInterval: number | undefined
   savedProjects: SavedProject[]
 }

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -74,3 +74,8 @@ interface GraphmlExtension {
 }
 
 export type CyGraphml = cytoscape.Core & GraphmlExtension
+
+export interface SavedProject {
+    hash: string,
+    name: string
+}

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -76,6 +76,7 @@ interface GraphmlExtension {
 export type CyGraphml = cytoscape.Core & GraphmlExtension
 
 export interface SavedProject {
-    hash: string,
-    name: string
+    id: string,
+    name: string,
+    hash: string
 }

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -75,6 +75,10 @@ interface GraphmlExtension {
 
 export type CyGraphml = cytoscape.Core & GraphmlExtension
 
+export interface NewProjectRequest {
+    name: string
+}
+
 export interface SavedProject {
     id: string,
     name: string,

--- a/app/client/src/views/ProjectView.vue
+++ b/app/client/src/views/ProjectView.vue
@@ -49,7 +49,7 @@
         </div>
       </div>
     </div>
-    <div v-else>
+    <div v-else id="loading-project">
         Loading...
     </div>
   </div>

--- a/app/client/src/views/ProjectView.vue
+++ b/app/client/src/views/ProjectView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="project">
+    <div v-if="projectId" class="project">
       <div class="file-input">
         <DropZone v-if="user && !submitStatus" class="dropzone-component"/>
       </div>
@@ -49,7 +49,9 @@
         </div>
       </div>
     </div>
-
+    <div v-else>
+        Loading...
+    </div>
   </div>
 </template>
 
@@ -91,7 +93,7 @@ export default defineComponent({
         }
     },
     computed: {
-        ...mapState(["user", "submitStatus", "analysisStatus", "projectName"]),
+        ...mapState(["user", "submitStatus", "analysisStatus", "projectId", "projectName"]),
         ...mapGetters(["uniqueClusters"])
     }
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -99,7 +99,6 @@ test.describe("Logged in Tests", () => {
         await expect(page.locator("#cy canvas")).toHaveCount(3);
         // can browse back to Home page and see new project in history
         await page.goto(config.clientUrl());
-        await expect(page.locator(".saved-project-row").count()).toBe(1);
-        await expect(page.locator(".saved-project-row").innerText()).toBe("test project");
+        await expect(await page.locator(".saved-project-row").innerText()).toBe("test project");
     });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -92,10 +92,14 @@ test.describe("Logged in Tests", () => {
         await expect(page.locator('tr:has-text("6930_8_13.fa") a')).toContainText("Visit Microreact URL");
         await expect(page.locator('tr:has-text("6930_8_13.fa") a'))
             .toHaveAttribute("href", /https:\/\/microreact.org\/project\/.*-poppunk.*/);
-        // nework visualisation component has 1 button for each cluster (=2) and renders canvases
+        // network visualisation component has 1 button for each cluster (=2) and renders canvases
         await page.click(".nav-link >> text=Network");
         await expect(page.locator("#cluster-tabs")).toHaveCount(2);
         await expect(page.locator("#cy")).toHaveCount(1);
         await expect(page.locator("#cy canvas")).toHaveCount(3);
+        // can browse back to Home page and see new project in history
+        await page.goto(config.clientUrl());
+        await expect(page.locator(".saved-project-row").count()).toBe(1);
+        await expect(page.locator(".saved-project-row").innerText()).toBe("test project");
     });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -99,6 +99,6 @@ test.describe("Logged in Tests", () => {
         await expect(page.locator("#cy canvas")).toHaveCount(3);
         // can browse back to Home page and see new project in history
         await page.goto(config.clientUrl());
-        await expect(await page.locator(".saved-project-row").innerText()).toBe("test project");
+        await expect(await page.locator(":nth-match(.saved-project-row, 1)").innerText()).toBe("test project");
     });
 });

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -24,6 +24,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         statusInterval: undefined,
         projectHash: null,
         projectName: null,
+        savedProjects: [],
         ...state
     };
 }

--- a/app/client/tests/mocks.ts
+++ b/app/client/tests/mocks.ts
@@ -24,6 +24,7 @@ export function mockRootState(state: Partial<RootState> = {}): RootState {
         statusInterval: undefined,
         projectHash: null,
         projectName: null,
+        projectId: null,
         savedProjects: [],
         ...state
     };

--- a/app/client/tests/unit/components/SavedProjects.spec.ts
+++ b/app/client/tests/unit/components/SavedProjects.spec.ts
@@ -1,0 +1,49 @@
+import Vuex from "vuex";
+import { RootState } from "@/store/state";
+import { shallowMount } from "@vue/test-utils";
+import SavedProjects from "@/components/SavedProjects.vue";
+import { mockRootState } from "../../mocks";
+
+describe("SavedProjects", () => {
+    const mockGetSavedProjects = jest.fn();
+
+    const getWrapper = () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                savedProjects: [
+                    { name: "project one", hash: "123abc" },
+                    { name: "project two", hash: "456def" }
+                ]
+            }),
+            actions: {
+                getSavedProjects: mockGetSavedProjects
+            }
+        });
+        return shallowMount(SavedProjects, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("h4").text()).toBe("Load a previously saved project");
+        const headers = wrapper.findAll(".saved-project-headers div");
+        expect(headers.length).toBe(1);
+        expect(headers.at(0)!.text()).toBe("Project name");
+        const projectRows = wrapper.findAll(".saved-project-row");
+        expect(projectRows.length).toBe(2);
+        expect(projectRows.at(0)!.find("div").text()).toBe("project one");
+        expect(projectRows.at(1)!.find("div").text()).toBe("project two");
+    });
+
+    it("dispatches getSavedProjects on load", () => {
+        getWrapper();
+        expect(mockGetSavedProjects).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/client/tests/unit/components/SavedProjects.spec.ts
+++ b/app/client/tests/unit/components/SavedProjects.spec.ts
@@ -11,8 +11,8 @@ describe("SavedProjects", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
                 savedProjects: [
-                    { name: "project one", hash: "123abc" },
-                    { name: "project two", hash: "456def" }
+                    { name: "project one", hash: "123abc", id: "ABC-123" },
+                    { name: "project two", hash: "456def", id: "DEF-123" }
                 ]
             }),
             actions: {

--- a/app/client/tests/unit/components/SelectAction.spec.ts
+++ b/app/client/tests/unit/components/SelectAction.spec.ts
@@ -7,7 +7,7 @@ import { mockRootState } from "../../mocks";
 
 describe("SelectAction", () => {
     const getUser = jest.fn();
-    const setProjectName = jest.fn();
+    const newProject = jest.fn();
     const mockRouter = {
         push: jest.fn()
     };
@@ -21,10 +21,8 @@ describe("SelectAction", () => {
             }
         }),
         actions: {
-            getUser
-        },
-        mutations: {
-            setProjectName
+            getUser,
+            newProject
         }
     });
     const getWrapper = () => mount(SelectAction, {
@@ -73,15 +71,15 @@ describe("SelectAction", () => {
         expect(emptyWrapper.find("div").exists()).toBe(false);
     });
 
-    test("enter name and click button sets project name and loads project page", async () => {
+    test("enter name and click button dispatches newProject and loads project page", async () => {
         const input = wrapper.find("#create-project-name");
         await input.setValue("test name");
         const button = wrapper.find("#create-project-btn");
         expect((button.element as HTMLButtonElement).disabled).toBe(false);
         await button.trigger("click");
 
-        expect(setProjectName).toHaveBeenCalledTimes(1);
-        expect(setProjectName.mock.calls[0][1]).toBe("test name");
+        expect(newProject).toHaveBeenCalledTimes(1);
+        expect(newProject.mock.calls[0][1]).toBe("test name");
         expect(mockRouter.push).toHaveBeenCalledTimes(1);
         expect(mockRouter.push).toHaveBeenCalledWith("/project");
     });
@@ -91,8 +89,8 @@ describe("SelectAction", () => {
         await input.setValue("test name");
         await input.trigger("keyup.enter");
 
-        expect(setProjectName).toHaveBeenCalledTimes(1);
-        expect(setProjectName.mock.calls[0][1]).toBe("test name");
+        expect(newProject).toHaveBeenCalledTimes(1);
+        expect(newProject.mock.calls[0][1]).toBe("test name");
         expect(mockRouter.push).toHaveBeenCalledTimes(1);
         expect(mockRouter.push).toHaveBeenCalledWith("/project");
     });
@@ -101,7 +99,7 @@ describe("SelectAction", () => {
         const input = wrapper.find("#create-project-name");
         await input.trigger("keyup.enter");
 
-        expect(setProjectName).toHaveBeenCalledTimes(0);
+        expect(newProject).toHaveBeenCalledTimes(0);
         expect(mockRouter.push).toHaveBeenCalledTimes(0);
     });
 });

--- a/app/client/tests/unit/components/SelectAction.spec.ts
+++ b/app/client/tests/unit/components/SelectAction.spec.ts
@@ -2,6 +2,7 @@ import SelectAction from "@/components/SelectAction.vue";
 import { mount, VueWrapper } from "@vue/test-utils";
 import { RootState } from "@/store/state";
 import Vuex from "vuex";
+import SavedProjects from "@/components/SavedProjects.vue";
 import { mockRootState } from "../../mocks";
 
 describe("SelectAction", () => {
@@ -58,6 +59,18 @@ describe("SelectAction", () => {
         const button = wrapper.find("button#create-project-btn");
         expect(button.text()).toBe("Create new project");
         expect((button.element as HTMLButtonElement).disabled).toBe(true);
+        expect(wrapper.findComponent(SavedProjects).exists()).toBe(true);
+    });
+
+    test("renders nothing when no user", () => {
+        const noUserStore = new Vuex.Store<RootState>({ state: mockRootState() });
+        const emptyWrapper = mount(SelectAction, {
+            global: {
+                plugins: [noUserStore]
+            }
+
+        });
+        expect(emptyWrapper.find("div").exists()).toBe(false);
     });
 
     test("enter name and click button sets project name and loads project page", async () => {

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -69,6 +69,32 @@ describe("Actions", () => {
         );
     });
 
+    it("newProject posts project name and commits returned id", async () => {
+        mockAxios.onPost(`${serverUrl}/project`)
+            .reply(200, responseSuccess("ABC-123"));
+        const commit = jest.fn();
+        await actions.newProject({ commit } as any, "testproj");
+        expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({name: "testproj"});
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit.mock.calls[0][0]).toBe("setProjectName");
+        expect(commit.mock.calls[0][1]).toBe("testproj");
+        expect(commit.mock.calls[1][0]).toBe("setProjectId");
+        expect(commit.mock.calls[1][1]).toBe("ABC-123");
+    });
+
+    it("newProject adds error response", async () => {
+        const error = {error: "test", detail: "test detail"};
+        mockAxios.onPost(`${serverUrl}/project`)
+            .reply(500, responseError(error));
+        const commit = jest.fn();
+        await actions.newProject({ commit } as any, "testproj");
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit.mock.calls[0][0]).toBe("setProjectName");
+        expect(commit.mock.calls[0][1]).toBe("testproj");
+        expect(commit.mock.calls[1][0]).toBe("addError");
+        expect(commit.mock.calls[1][1]).toStrictEqual(error);
+    });
+
     it("logoutUser makes axios call", async () => {
         mockAxios.onGet(`${serverUrl}/logout`).reply(200);
         await actions.logoutUser();
@@ -93,7 +119,7 @@ describe("Actions", () => {
     it("runPoppunk makes axios call", async () => {
         const commit = jest.fn();
         const state = mockRootState({
-            projectName: "test project",
+            projectId: "test-project",
             results: {
                 perIsolate: {
                     someFileHash: {
@@ -116,7 +142,7 @@ describe("Actions", () => {
         expect(mockAxios.history.post[0].url).toEqual(`${serverUrl}/poppunk`);
         expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({
             projectHash: expectedHash,
-            projectName: "test project",
+            projectId: "test-project",
             sketches: {
                 someFileHash: { 14: "12345" },
                 someFileHash2: { 14: "12345" }

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -74,7 +74,7 @@ describe("Actions", () => {
             .reply(200, responseSuccess("ABC-123"));
         const commit = jest.fn();
         await actions.newProject({ commit } as any, "testproj");
-        expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({name: "testproj"});
+        expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({ name: "testproj" });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe("setProjectName");
         expect(commit.mock.calls[0][1]).toBe("testproj");
@@ -83,7 +83,7 @@ describe("Actions", () => {
     });
 
     it("newProject adds error response", async () => {
-        const error = {error: "test", detail: "test detail"};
+        const error = { error: "test", detail: "test detail" };
         mockAxios.onPost(`${serverUrl}/project`)
             .reply(500, responseError(error));
         const commit = jest.fn();

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -162,6 +162,11 @@ describe("mutations", () => {
         mutations.setProjectName(state, "test name");
         expect(state.projectName).toBe("test name");
     });
+    it("sets project id", () => {
+        const state = mockRootState();
+        mutations.setProjectId(state, "ABC-123");
+        expect(state.projectId).toBe("ABC-123");
+    });
     it("sets saved projects", () => {
         const state = mockRootState();
         const projects = [{ hash: "123", name: "proj 1", id: "abc" }, { hash: "456", name: "proj 2", id: "def" }];

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -164,7 +164,7 @@ describe("mutations", () => {
     });
     it("sets saved projects", () => {
         const state = mockRootState();
-        const projects = [{ hash: "123", name: "proj 1" }, { hash: "456", name: "proj 2" }];
+        const projects = [{ hash: "123", name: "proj 1", id: "abc" }, { hash: "456", name: "proj 2", id: "def" }];
         mutations.setSavedProjects(state, projects);
         expect(state.savedProjects).toBe(projects);
     });

--- a/app/client/tests/unit/store/mutations.spec.ts
+++ b/app/client/tests/unit/store/mutations.spec.ts
@@ -162,4 +162,10 @@ describe("mutations", () => {
         mutations.setProjectName(state, "test name");
         expect(state.projectName).toBe("test name");
     });
+    it("sets saved projects", () => {
+        const state = mockRootState();
+        const projects = [{ hash: "123", name: "proj 1" }, { hash: "456", name: "proj 2" }];
+        mutations.setSavedProjects(state, projects);
+        expect(state.savedProjects).toBe(projects);
+    });
 });

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -59,6 +59,7 @@ describe("Project", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
                 projectName: "testProject",
+                projectId: "ABC-123",
                 user: {
                     name: "Jane",
                     id: "543653d45",
@@ -145,11 +146,13 @@ describe("Project", () => {
         expect(wrapper.vm.selectedTab).toBe("table");
         tabs[1].trigger("click");
         expect(wrapper.vm.selectedTab).toBe("network");
+        expect(wrapper.find("#loading-project").exists()).toBe(false);
     });
 
     it("redirects to root if no project name", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
+                projectId: "ABC-123",
                 projectName: null,
                 user: {
                     name: "Jane",
@@ -173,5 +176,33 @@ describe("Project", () => {
         expect(getUser).not.toHaveBeenCalled();
         expect(mockRouter.push).toHaveBeenCalledTimes(1);
         expect(mockRouter.push.mock.calls[0][0]).toBe("/");
+    });
+
+    it("displays placeholder if no project id", () => {
+        const store = new Vuex.Store<RootState>({
+            state: mockRootState({
+                projectId: null,
+                projectName: "test",
+                user: {
+                    name: "Jane",
+                    id: "543653d45",
+                    provider: "google"
+                }
+            }),
+            actions: {
+                getUser
+            }
+        });
+        const wrapper = mount(ProjectView, {
+            global: {
+                plugins: [store],
+                mocks: {
+                    $router: mockRouter
+                }
+            }
+        });
+
+        expect(wrapper.find("div.router").exists()).toBe(false);
+        expect(wrapper.find("div#loading-project").text()).toBe("Loading...");
     });
 });

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -18,6 +18,7 @@ describe("Project", () => {
         const store = new Vuex.Store<RootState>({
             state: mockRootState({
                 projectName: "test project",
+                projectId: "ABC-123",
                 user: {
                     name: "Jane",
                     id: "543653d45",

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -24,7 +24,8 @@
         "passport-github": "^1.1.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-mock-strategy": "^2.0.0",
-        "ts-node": "^10.7.0"
+        "ts-node": "^10.7.0",
+        "uid": "^2.0.1"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -2441,6 +2442,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
+      "integrity": "sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -13239,6 +13248,17 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.1.tgz",
+      "integrity": "sha512-PF+1AnZgycpAIEmNtjxGBVmKbZAQguaa4pBUq6KNaGEcpzZ2klCNZLM34tsjp76maN00TttiiUf6zkIBpJQm2A==",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -15686,6 +15706,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@lukeed/csprng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
+      "integrity": "sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -23840,6 +23865,14 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+    },
+    "uid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.1.tgz",
+      "integrity": "sha512-PF+1AnZgycpAIEmNtjxGBVmKbZAQguaa4pBUq6KNaGEcpzZ2klCNZLM34tsjp76maN00TttiiUf6zkIBpJQm2A==",
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
+      }
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -28,7 +28,8 @@
     "passport-github": "^1.1.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-mock-strategy": "^2.0.0",
-    "ts-node": "^10.7.0"
+    "ts-node": "^10.7.0",
+    "uid": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -34,7 +34,11 @@ export class UserStore {
 
         const result = [];
         for (const projectHash of allHashes) {
-            const project = await this._redis.hmget(this._userProjectKey(user, projectHash), "name");
+            const name = await this._redis.hget(this._userProjectKey(user, projectHash), "name");
+            const project = {
+                hash: projectHash,
+                name
+            };
             result.push(project);
         }
 

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -23,6 +23,15 @@ export class UserStore {
         const userProjectId = this._userProjectId(user, projectHash);
         await this._redis.hset(this._userProjectKey("name"), userProjectId, projectName);
     }
+
+    async getUserProjects(request) {
+        const user = this._userIdFromRequest(request);
+        // get all hashes
+        const result = await this._redis.hget(this._userKey("hash"), user);
+        console.log("got user hashes:" +  JSON.stringify(result));
+
+        return result;
+    }
 }
 
 export const userStore = (redis: Redis) => new UserStore(redis);

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -25,7 +25,8 @@ export class UserStore {
     }
 
     async saveProjectHash(request, projectId: string, projectHash: string) {
-        // TODO: could verify that this project belongs to the request user
+        // TODO: verify that this project belongs to the request user:
+        // https://mrc-ide.myjetbrains.com/youtrack/issue/bacpop-96
         await this._redis.hset(this._projectKey(projectId), "hash", projectHash);
     }
 
@@ -37,7 +38,6 @@ export class UserStore {
         const projectIds = await this._redis.lrange(projectIdsKey, 0, count-1);
 
         const result = [];
-        // TODO: pipeline this?
         for (const projectId of projectIds) {
             const values = await this._redis.hmget(this._projectKey(projectId), "name", "hash");
             result.push({

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -34,18 +34,17 @@ export class UserStore {
         // Get all project ids for the user
         const user = this._userIdFromRequest(request);
         const projectIdsKey = this._userProjectsKey(user);
-        const count = await this._redis.llen(projectIdsKey);
-        const projectIds = await this._redis.lrange(projectIdsKey, 0, count-1);
+        const projectIds = await this._redis.lrange(projectIdsKey, 0, -1);
 
         const result = [];
-        for (const projectId of projectIds) {
+        await Promise.all(projectIds.map(async (projectId: string) => {
             const values = await this._redis.hmget(this._projectKey(projectId), "name", "hash");
             result.push({
                 id: projectId,
                 name: values[0],
                 hash: values[1]
             });
-        }
+        }));
 
         return result;
     }

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -17,7 +17,6 @@ export class UserStore {
     // details.
     private _userProjectKey = (userId: string, projectHash: string) => `${USER_PROJECT_PREFIX}${userId}:${projectHash}`;
     private _userIdFromRequest = (request) => `${request.user.provider}:${request.user.id}`;
-    //private _userProjectId = (userId, projectHash) => `${userId}:${projectHash}`
 
      async saveNewProject(request, projectHash: string, projectName: string) {
         const user = this._userIdFromRequest(request);

--- a/app/server/src/requestTypes.ts
+++ b/app/server/src/requestTypes.ts
@@ -5,5 +5,9 @@ export interface PoppunkRequest {
 }
 
 export interface BeebopRunRequest extends PoppunkRequest {
-    projectName: string,
+    projectId: string,
+}
+
+export interface NewProjectRequest {
+    name: string
 }

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -44,25 +44,16 @@ export const router = ((app, config) => {
         authCheck,
         (request, response) => {
             if (request.user.provider == 'github') {
-                response.json({
-                    status: 'success',
-                    errors: [],
-                    data: {
-                        id: request.user.id,
-                        provider: request.user.provider,
-                        name: request.user.username
-                    }
-                    
+                sendSuccess(response, {
+                    id: request.user.id,
+                    provider: request.user.provider,
+                    name: request.user.username
                 });
             } else {
-                response.json({
-                    status: 'success',
-                    errors: [],
-                    data: {
-                        id: request.user.id,
-                        provider: request.user.provider,
-                        name: request.user.name.givenName
-                    }    
+                sendSuccess(response, {
+                    id: request.user.id,
+                    provider: request.user.provider,
+                    name: request.user.name.givenName
                 });
             }
         }
@@ -158,10 +149,6 @@ export const apiEndpoints = (config => ({
             const {projectHash, projectName, names, sketches} = poppunkRequest;
             const {redis} = request.app.locals;
             await userStore(redis).saveNewProject(request, projectHash, projectName);
-
-            //TODO: this is for testing only, put list fetch into separate endpoint
-            await userStore(redis).getUserProjects(request);
-
             const apiRequest = {names, projectHash, sketches} as PoppunkRequest;
             await axios.post(`${config.api_url}/poppunk`,
                 apiRequest,

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import passport, {authenticate} from 'passport';
+import passport from 'passport';
 import {BeebopRunRequest, NewProjectRequest, PoppunkRequest} from "../requestTypes";
 import {userStore} from "../db/userStore";
 import asyncHandler from "../errors/asyncHandler";

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -184,7 +184,7 @@ export const apiEndpoints = (config => ({
         await asyncHandler(next, async () => {
             const {redis} = request.app.locals;
             const projects = await userStore(redis).getUserProjects(request);
-            response.json(projects);
+            sendSuccess(response, projects);
         });
     },
 
@@ -241,4 +241,12 @@ function sendError(response, error) {
             data: null
         })  
     }
+}
+
+function sendSuccess(response, data) {
+    response.json({
+        status: 'success',
+        errors: [],
+        data
+    });
 }

--- a/app/server/src/routes/routes.ts
+++ b/app/server/src/routes/routes.ts
@@ -22,6 +22,10 @@ export const router = ((app, config) => {
         authCheck,
         api.runPoppunk);
 
+    app.get('/projects',
+        authCheck,
+        api.getProjects);
+
     app.post('/status',
         authCheck,
         api.getStatus);
@@ -155,6 +159,9 @@ export const apiEndpoints = (config => ({
             const {redis} = request.app.locals;
             await userStore(redis).saveNewProject(request, projectHash, projectName);
 
+            //TODO: this is for testing only, put list fetch into separate endpoint
+            await userStore(redis).getUserProjects(request);
+
             const apiRequest = {names, projectHash, sketches} as PoppunkRequest;
             await axios.post(`${config.api_url}/poppunk`,
                 apiRequest,
@@ -170,6 +177,14 @@ export const apiEndpoints = (config => ({
                 .catch(function (error) {
                     sendError(response, error);
                 })
+        });
+    },
+
+    async getProjects(request, response, next) {
+        await asyncHandler(next, async () => {
+            const {redis} = request.app.locals;
+            const projects = await userStore(redis).getUserProjects(request);
+            response.json(projects);
         });
     },
 

--- a/app/server/tests/integration/persistence.test.ts
+++ b/app/server/tests/integration/persistence.test.ts
@@ -1,4 +1,4 @@
-import {get, post, flushRedis, getRedisValues} from "./utils";
+import {get, post, flushRedis, getRedisHash, getRedisList, saveRedisHash, saveRedisList} from "./utils";
 describe("User persistence", () => {
     let connectionCookie = "";
     beforeEach(async () => {
@@ -14,10 +14,26 @@ describe("User persistence", () => {
             projectName: "test name"
         };
         await post("poppunk", payload, connectionCookie);
-        const mapping = await getRedisValues("beebop:user:hash");
-        expect(Object.keys(mapping).length).toBe(1);
-        expect(mapping["mock:1234"]).toBe("9876");
-        const nameMapping = await getRedisValues("beebop:userproject:name");
-        expect(nameMapping["mock:1234:9876"]).toBe("test name");
+        const userHashes = await getRedisList("beebop:user:hashes:mock:1234");
+        expect(userHashes).toStrictEqual(["9876"]);
+        const projectDetails = await getRedisHash("beebop:userproject:mock:1234:9876");
+        expect(projectDetails).toStrictEqual({name: "test name"});
+    });
+
+    it("gets user project details from redis", async () => {
+        await saveRedisList("beebop:user:hashes:mock:1234", ["abcd", "efgh"]);
+        await saveRedisHash("beebop:userproject:mock:1234:abcd", {name: "test save 1"});
+        await saveRedisHash("beebop:userproject:mock:1234:efgh", {name: "test save 2"});
+
+        const response = await get("projects", connectionCookie);
+        expect(response.status).toBe(200);
+        expect(response.data).toStrictEqual({
+            status: "success",
+            data: [
+                {hash: "abcd", name: "test save 1"},
+                {hash: "efgh", name: "test save 2"}
+            ],
+            errors: []
+        });
     });
 });

--- a/app/server/tests/integration/persistence.test.ts
+++ b/app/server/tests/integration/persistence.test.ts
@@ -8,30 +8,44 @@ describe("User persistence", () => {
         connectionCookie = response.headers["set-cookie"][0];
     });
 
-    it("adds user - project hash - project name mappings to redis", async () => {
+    it("adds user project to redis", async () => {
+        const payload = {
+            name: "test name"
+        };
+        await post("project", payload, connectionCookie);
+        const userProjects = await getRedisList("beebop:userprojects:mock:1234")
+        expect(userProjects.length).toBe(1);
+        const projectId = userProjects[0];
+        expect(projectId.length).toBe(32);
+        const projectDetails = await getRedisHash(`beebop:project:${projectId}`);
+        expect(projectDetails).toStrictEqual({
+            name: "test name"
+        });
+    });
+
+    it("adds project's hash to redis", async () => {
+        await saveRedisHash("beebop:project:test-project-id", {name: "test project name"});
         const payload = {
             projectHash: "9876",
-            projectName: "test name"
+            projectId: "test-project-id"
         };
         await post("poppunk", payload, connectionCookie);
-        const userHashes = await getRedisList("beebop:user:hashes:mock:1234");
-        expect(userHashes).toStrictEqual(["9876"]);
-        const projectDetails = await getRedisHash("beebop:userproject:mock:1234:9876");
-        expect(projectDetails).toStrictEqual({name: "test name"});
+        const projectDetails = await getRedisHash("beebop:project:test-project-id");
+        expect(projectDetails).toStrictEqual({name: "test project name", hash: "9876"});
     });
 
     it("gets user project details from redis", async () => {
-        await saveRedisList("beebop:user:hashes:mock:1234", ["abcd", "efgh"]);
-        await saveRedisHash("beebop:userproject:mock:1234:abcd", {name: "test save 1"});
-        await saveRedisHash("beebop:userproject:mock:1234:efgh", {name: "test save 2"});
+        await saveRedisList("beebop:userprojects:mock:1234", ["abcd", "efgh"]);
+        await saveRedisHash("beebop:project:abcd", {name: "test save 1"});
+        await saveRedisHash("beebop:project:efgh", {name: "test save 2", hash: "1234"});
 
         const response = await get("projects", connectionCookie);
         expect(response.status).toBe(200);
         expect(response.data).toStrictEqual({
             status: "success",
             data: [
-                {hash: "abcd", name: "test save 1"},
-                {hash: "efgh", name: "test save 2"}
+                {id: "abcd", name: "test save 1", hash: null},
+                {id: "efgh", name: "test save 2", hash: "1234"}
             ],
             errors: []
         });

--- a/app/server/tests/unit/db/userStore.test.ts
+++ b/app/server/tests/unit/db/userStore.test.ts
@@ -6,7 +6,9 @@ describe("UserStore", () => {
         lpush: jest.fn(),
         llen: jest.fn().mockImplementation(() => 2),
         lrange: jest.fn().mockImplementation(() => ["123", "456"]),
-        hget: jest.fn().mockImplementation((key: string, valueName: string) => `${valueName} for ${key}`)
+        hmget: jest.fn().mockImplementation((key: string, ...valueNames: string[]) => {
+            return valueNames.map((valueName) => `${valueName} for ${key}`);
+        })
     } as any;
 
     const mockRequest = {
@@ -22,29 +24,39 @@ describe("UserStore", () => {
 
     it("saves new project data", async () => {
         const sut = new UserStore(mockRedis);
-        await sut.saveNewProject(mockRequest, "testProjectHash", "test project name");
+        await sut.saveNewProject(mockRequest, "test project name");
         expect(mockRedis.lpush).toHaveBeenCalledTimes(1);
-        expect(mockRedis.lpush.mock.calls[0][0]).toBe("beebop:user:hashes:testProvider:testId");
-        expect(mockRedis.lpush.mock.calls[0][1]).toBe("testProjectHash");
+        expect(mockRedis.lpush.mock.calls[0][0]).toBe("beebop:userprojects:testProvider:testId");
+        const projectId = mockRedis.lpush.mock.calls[0][1];
+        expect(projectId.length).toBe(32);
 
         expect(mockRedis.hset).toHaveBeenCalledTimes(1);
-        expect(mockRedis.hset.mock.calls[0][0]).toBe("beebop:userproject:testProvider:testId:testProjectHash");
+        expect(mockRedis.hset.mock.calls[0][0]).toBe(`beebop:project:${projectId}`);
         expect(mockRedis.hset.mock.calls[0][1]).toBe("name");
         expect(mockRedis.hset.mock.calls[0][2]).toBe("test project name");
+    });
+
+    it("saves project hash", async () => {
+        const sut = new UserStore(mockRedis);
+        await sut.saveProjectHash(mockRequest, "testProjectId", "testProjectHash");
+        expect(mockRedis.hset).toHaveBeenCalledTimes(1);
+        expect(mockRedis.hset.mock.calls[0][0]).toBe("beebop:project:testProjectId");
+        expect(mockRedis.hset.mock.calls[0][1]).toBe("hash");
+        expect(mockRedis.hset.mock.calls[0][2]).toBe("testProjectHash");
     });
 
     it("gets user projects", async () => {
         const sut = new UserStore(mockRedis);
         const result = await sut.getUserProjects(mockRequest);
         expect(result).toStrictEqual([
-            {hash: "123", name: "name for beebop:userproject:testProvider:testId:123"},
-            {hash: "456", name: "name for beebop:userproject:testProvider:testId:456"}
+            {id: "123", name: "name for beebop:project:123", hash: "hash for beebop:project:123"},
+            {id: "456", name: "name for beebop:project:456", hash: "hash for beebop:project:456"}
         ]);
 
         expect(mockRedis.llen).toHaveBeenCalledTimes(1);
-        expect(mockRedis.llen.mock.calls[0][0]).toBe("beebop:user:hashes:testProvider:testId");
+        expect(mockRedis.llen.mock.calls[0][0]).toBe("beebop:userprojects:testProvider:testId");
         expect(mockRedis.lrange).toHaveBeenCalledTimes(1);
-        expect(mockRedis.lrange.mock.calls[0][0]).toBe("beebop:user:hashes:testProvider:testId");
+        expect(mockRedis.lrange.mock.calls[0][0]).toBe("beebop:userprojects:testProvider:testId");
         expect(mockRedis.lrange.mock.calls[0][1]).toBe(0);
         expect(mockRedis.lrange.mock.calls[0][2]).toBe(1);
     });

--- a/app/server/tests/unit/db/userStore.test.ts
+++ b/app/server/tests/unit/db/userStore.test.ts
@@ -4,7 +4,6 @@ describe("UserStore", () => {
     const mockRedis = {
         hset: jest.fn(),
         lpush: jest.fn(),
-        llen: jest.fn().mockImplementation(() => 2),
         lrange: jest.fn().mockImplementation(() => ["123", "456"]),
         hmget: jest.fn().mockImplementation((key: string, ...valueNames: string[]) => {
             return valueNames.map((valueName) => `${valueName} for ${key}`);
@@ -53,12 +52,10 @@ describe("UserStore", () => {
             {id: "456", name: "name for beebop:project:456", hash: "hash for beebop:project:456"}
         ]);
 
-        expect(mockRedis.llen).toHaveBeenCalledTimes(1);
-        expect(mockRedis.llen.mock.calls[0][0]).toBe("beebop:userprojects:testProvider:testId");
         expect(mockRedis.lrange).toHaveBeenCalledTimes(1);
         expect(mockRedis.lrange.mock.calls[0][0]).toBe("beebop:userprojects:testProvider:testId");
         expect(mockRedis.lrange.mock.calls[0][1]).toBe(0);
-        expect(mockRedis.lrange.mock.calls[0][2]).toBe(1);
+        expect(mockRedis.lrange.mock.calls[0][2]).toBe(-1);
     });
 
 });


### PR DESCRIPTION
This branch adds the start of a project history section to beebop's front page, so that the names of the user's previous projects appear when the page loads. A project does not need to have had analysis started to appear in the page. Only name is shown - date will be added in a further ticket, as will the ability to click the project name to load the project data. 

I've refactored the saving of user project name in the back end. Projects now have unique project ids generated when first created - a new endpoint is called when this happens, and the the project id is returned and set in the front end state. When analysis starts, the project hash is send to backend as before, and included in the project details saved for the id. 

When you load the homepage after login, and inspect the response from the `/projects` endpoint you should see that `hash` is null for projects which have not begun an analysis, and set for those which have. 

