### PR TITLE
bacpop-97 Clear store state on new project

### DIFF
--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -7,6 +7,7 @@ import {
     Versions, User, AnalysisStatus, ClusterInfo, Dict, SavedProject, NewProjectRequest
 } from "@/types";
 import { api } from "@/apiService";
+import { emptyState } from "@/utils";
 
 axios.defaults.withCredentials = true;
 const serverUrl = config.serverUrl();
@@ -25,7 +26,11 @@ export default {
             .get<User>(`${serverUrl}/user`);
     },
     async newProject(context: ActionContext<RootState, RootState>, name: string) {
-        const { commit } = context;
+        const { commit, state } = context;
+        // We assume that the latest current project state has been persisted so we can immediately use empty state for
+        // new project
+        Object.assign(state, emptyState());
+
         commit("setProjectName", name);
         await api(context)
             .withSuccess("setProjectId")

--- a/app/client/src/store/index.ts
+++ b/app/client/src/store/index.ts
@@ -3,29 +3,10 @@ import actions from "@/store/actions";
 import mutations from "@/store/mutations";
 import { getters } from "@/store/getters";
 import { RootState } from "@/store/state";
+import { emptyState } from "@/utils";
 
 export default new Vuex.Store<RootState>({
-    state: {
-        errors: [],
-        versions: [],
-        user: null,
-        microreactToken: null,
-        results: {
-            perIsolate: {},
-            perCluster: {}
-        },
-        projectName: null,
-        projectId: null,
-        projectHash: null,
-        submitStatus: null,
-        analysisStatus: {
-            assign: null,
-            microreact: null,
-            network: null
-        },
-        statusInterval: undefined,
-        savedProjects: []
-    },
+    state: emptyState(),
     getters,
     mutations,
     actions,

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -1,3 +1,27 @@
+import { RootState } from "@/store/state";
+
+export const emptyState = (): RootState => ({
+    errors: [],
+    versions: [],
+    user: null,
+    microreactToken: null,
+    results: {
+        perIsolate: {},
+        perCluster: {}
+    },
+    projectName: null,
+    projectId: null,
+    projectHash: null,
+    submitStatus: null,
+    analysisStatus: {
+        assign: null,
+        microreact: null,
+        network: null
+    },
+    statusInterval: undefined,
+    savedProjects: []
+});
+
 export function addRowspan(tableSorted: Record<string, string | number>[]) {
     // extract cluster numbers
     const clusters = tableSorted.map((a) => a.Cluster);

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -1,9 +1,15 @@
 /// <reference lib="dom"/>
 /* eslint-disable no-tabs */
 
-import { test, expect } from "@playwright/test";
+import {test, expect, Page} from "@playwright/test";
 import { readFileSync } from "fs";
 import config from "../../src/settings/development/config";
+
+const createProject = async (projectName: string, page: Page) => {
+    await page.fill("input#create-project-name", "test project");
+    await page.click("button#create-project-btn");
+    expect(await page.locator("#no-results").innerText()).toBe("No data uploaded yet");
+};
 
 test.describe("Logged in Tests", () => {
     test.beforeEach(async ({ page }) => {
@@ -23,8 +29,7 @@ test.describe("Logged in Tests", () => {
     });
 
     test("should display dropzone in Project view", async ({ page }) => {
-        await page.fill("input#create-project-name", "test project");
-        await page.click("button#create-project-btn");
+        await createProject("test project", page);
         await expect(page.locator(".dropzone")).toBeVisible();
         await expect(page.locator("h2")).toContainText("Project: test project");
     });
@@ -34,9 +39,8 @@ test.describe("Logged in Tests", () => {
         await expect(await page.locator("button#create-project-btn")).toBeVisible();
     });
 
-    test("should update file list on drop, process them in WebWorker and submit on click", async ({ page }) => {
-        await page.fill("input#create-project-name", "test project");
-        await page.click("button#create-project-btn");
+    test("should behave as expected when doing full project analysis, then new project", async ({ page }) => {
+        await createProject("test project", page);
         // Read files into a buffer
         const buffer = readFileSync("./tests/files/6930_8_13.fa", { encoding: "utf8", flag: "r" });
         const buffer2 = readFileSync("./tests/files/6930_8_11.fa", { encoding: "utf8", flag: "r" });
@@ -100,5 +104,7 @@ test.describe("Logged in Tests", () => {
         // can browse back to Home page and see new project in history
         await page.goto(config.clientUrl());
         await expect(await page.locator(":nth-match(.saved-project-row, 1)").innerText()).toBe("test project");
+        // can create a new empty project
+        await createProject("another test project", page);
     });
 });

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -4,6 +4,7 @@ import { Md5 } from "ts-md5/dist/md5";
 import { BeebopError } from "@/types";
 import config from "../../../src/settings/development/config";
 import { mockAxios, mockRootState } from "../../mocks";
+import {emptyState} from "@/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function responseSuccess(data : any) {
@@ -69,12 +70,20 @@ describe("Actions", () => {
         );
     });
 
-    it("newProject posts project name and commits returned id", async () => {
+    it("newProject clears state, posts project name and commits returned id", async () => {
         mockAxios.onPost(`${serverUrl}/project`)
             .reply(200, responseSuccess("ABC-123"));
         const commit = jest.fn();
-        await actions.newProject({ commit } as any, "testproj");
+        const state = {
+            ...emptyState(),
+            projectId: "123",
+            projectHash: "abc",
+            errors: ["test error"],
+            submitStatus: "test status"
+        } as any;
+        await actions.newProject({ commit, state } as any, "testproj");
         expect(JSON.parse(mockAxios.history.post[0].data)).toStrictEqual({ name: "testproj" });
+        expect(state).toStrictEqual(emptyState());
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe("setProjectName");
         expect(commit.mock.calls[0][1]).toBe("testproj");

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -2,9 +2,9 @@ import actions from "@/store/actions";
 import versionInfo from "@/resources/versionInfo.json";
 import { Md5 } from "ts-md5/dist/md5";
 import { BeebopError } from "@/types";
+import { emptyState } from "@/utils";
 import config from "../../../src/settings/development/config";
 import { mockAxios, mockRootState } from "../../mocks";
-import {emptyState} from "@/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function responseSuccess(data : any) {
@@ -96,7 +96,8 @@ describe("Actions", () => {
         mockAxios.onPost(`${serverUrl}/project`)
             .reply(500, responseError(error));
         const commit = jest.fn();
-        await actions.newProject({ commit } as any, "testproj");
+        const state = emptyState();
+        await actions.newProject({ commit, state } as any, "testproj");
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe("setProjectName");
         expect(commit.mock.calls[0][1]).toBe("testproj");

--- a/app/client/tests/unit/utils.spec.ts
+++ b/app/client/tests/unit/utils.spec.ts
@@ -1,4 +1,4 @@
-import { addRowspan, getRGB, verbalProb } from "../../src/utils";
+import {addRowspan, emptyState, getRGB, verbalProb} from "../../src/utils";
 
 describe("util functions", () => {
     const sortedTable = [
@@ -63,5 +63,30 @@ describe("util functions", () => {
         expect(verbalProb(0.6, "Cotrim")).toEqual("Very good chance");
         expect(verbalProb(0.4, "Cotrim")).toEqual("Probably not");
         expect(verbalProb(0.1, "Cotrim")).toEqual("Unlikely");
+    });
+
+    it("generates empty state", () => {
+        const state = emptyState();
+        expect(state).toStrictEqual({
+            errors: [],
+            versions: [],
+            user: null,
+            microreactToken: null,
+            results: {
+                perIsolate: {},
+                perCluster: {}
+            },
+            projectName: null,
+            projectId: null,
+            projectHash: null,
+            submitStatus: null,
+            analysisStatus: {
+                assign: null,
+                microreact: null,
+                network: null
+            },
+            statusInterval: undefined,
+            savedProjects: []
+        });
     });
 });

--- a/app/client/tests/unit/utils.spec.ts
+++ b/app/client/tests/unit/utils.spec.ts
@@ -1,4 +1,6 @@
-import {addRowspan, emptyState, getRGB, verbalProb} from "../../src/utils";
+import {
+    addRowspan, emptyState, getRGB, verbalProb
+} from "../../src/utils";
 
 describe("util functions", () => {
     const sortedTable = [


### PR DESCRIPTION
This branch clears the store state on new project so that a new project does not load with the files etc from any previous loaded project. Will be used in conjunction with [bacpop-98](https://mrc-ide.myjetbrains.com/youtrack/issue/bacpop-98) which should ensure latest project state is always persisted. 

Introduces `emptyState()` util, which is used to initialise the first store state, and to create fresh new projects. Note that this will also clear non-project store props, like versions and savedProjects - but these are always refreshed from API when needed, so it shouldn't matter..