### PR TITLE
bacpop-138 Validate project name change

### DIFF
--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="!editingProjectName">
+  <template v-if="!editingProjectName">
         <slot></slot>
         <i class="bi bi-pencil edit-icon clickable"
            v-b-tooltip.hover
@@ -7,8 +7,8 @@
            @click="editProjectName"
            v-on:keyup.enter="editProjectName"
         ></i>
-    </span>
-    <span v-else>
+    </template>
+    <template v-else>
         <input ref="renameProject"
                class="project-name-input"
                type="text"
@@ -23,32 +23,31 @@
         <button @click="cancelEditProjectName" id="cancel-project-name" class="btn ms-1" :class="buttonClass">
             Cancel
         </button>
-        <br/>
         <project-name-check-message :check-result="checkResult"></project-name-check-message>
-    </span>
+    </template>
 </template>
 <script lang="ts">
 import { VBTooltip } from "bootstrap-vue-3";
 import { defineComponent } from "vue";
-import {mapActions, mapGetters} from "vuex";
+import { mapActions, mapGetters } from "vuex";
 import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessage.vue";
-import {ProjectNameCheckResult} from "@/types";
+import { ProjectNameCheckResult } from "@/types";
 
 export default defineComponent({
     name: "EditProjectName",
-    components: {ProjectNameCheckMessage},
+    components: { ProjectNameCheckMessage },
     directives: {
         "b-tooltip": VBTooltip
     },
     props: {
         projectId: String,
-        projectName: {type: String, required: true},
+        projectName: { type: String, required: true },
         buttonClass: String
     },
     data() {
         return {
             editingProjectName: false,
-            checkResult: null,
+            checkResult: ProjectNameCheckResult.Unchanged,
             inputText: ""
         };
     },
@@ -57,13 +56,12 @@ export default defineComponent({
             return this.checkResult === ProjectNameCheckResult.OK || this.checkResult === ProjectNameCheckResult.Unchanged;
         },
         inputModel: {
-            get(){
+            get() {
                 return this.inputText;
             },
             set(value: string) {
                 this.inputText = value;
                 this.checkResult = this.checkProjectName()(this.inputText, this.projectName);
-                console.log("change: " + this.checkResult)
             }
         }
     },
@@ -72,7 +70,7 @@ export default defineComponent({
         ...mapGetters(["checkProjectName"]),
         editProjectName() {
             this.editingProjectName = true;
-            this.checkResult = null;
+            this.checkResult = ProjectNameCheckResult.Unchanged;
             this.inputText = this.projectName;
         },
         cancelEditProjectName() {
@@ -81,7 +79,7 @@ export default defineComponent({
         saveProjectName() {
             if (this.canSave) {
                 if (this.checkResult !== ProjectNameCheckResult.Unchanged) {
-                    this.renameProject({projectId: this.projectId, name: this.inputText});
+                    this.renameProject({ projectId: this.projectId, name: this.inputText });
                 }
                 this.editingProjectName = false;
             }

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -34,7 +34,7 @@
 </template>
 <script lang="ts">
 import { VBTooltip } from "bootstrap-vue-3";
-import {defineComponent} from "vue";
+import { defineComponent } from "vue";
 import { mapActions, mapGetters } from "vuex";
 import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessage.vue";
 import { ProjectNameCheckResult } from "@/types";

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -18,7 +18,7 @@
                    v-on:keyup.enter="saveProjectName"
                    v-model="inputModel"
                    />
-            <button @click="saveProjectName"
+            <button @mousedown="saveProjectName"
                     id="save-project-name"
                     class="btn ms-2"
                     :class="buttonClass"

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -98,7 +98,7 @@ export default defineComponent({
 </script>
 <style scoped>
 .edit-project-name {
-    height: 2em;
+    height: 2.6em;
 }
 
 .edit-icon {

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -1,38 +1,40 @@
 <template>
-  <template v-if="!editingProjectName">
-        <slot></slot>
-        <i class="bi bi-pencil edit-icon clickable"
-           v-b-tooltip.hover
-           title="Edit Project Name"
-           @click="editProjectName"
-           v-on:keyup.enter="editProjectName"
-        ></i>
-    </template>
-    <template v-else>
-        <input ref="renameProject"
-               class="project-name-input"
-               type="text"
-               style="display:inline"
-               aria-label="New project name"
-               v-on:keyup.enter="saveProjectName"
-               v-model="inputModel"
-               />
-        <button @click="saveProjectName"
-                id="save-project-name"
-                class="btn ms-2"
-                :class="buttonClass"
-                :disabled="!canSave">
-            Save
-        </button>
-        <button @click="cancelEditProjectName" id="cancel-project-name" class="btn ms-1" :class="buttonClass">
-            Cancel
-        </button>
-        <project-name-check-message :check-result="checkResult"></project-name-check-message>
-    </template>
+    <div @focusout="cancelEditProjectName" class="edit-project-name">
+        <template v-if="!editingProjectName">
+            <slot></slot>
+            <i class="bi bi-pencil edit-icon clickable"
+               v-b-tooltip.hover
+               title="Edit Project Name"
+               @click="editProjectName"
+               v-on:keyup.enter="editProjectName"
+            ></i>
+        </template>
+        <template v-else>
+            <input ref="renameProject"
+                   class="project-name-input"
+                   type="text"
+                   style="display:inline"
+                   aria-label="New project name"
+                   v-on:keyup.enter="saveProjectName"
+                   v-model="inputModel"
+                   />
+            <button @click="saveProjectName"
+                    id="save-project-name"
+                    class="btn ms-2"
+                    :class="buttonClass"
+                    :disabled="!canSave">
+                Save
+            </button>
+            <button @click="cancelEditProjectName" id="cancel-project-name" class="btn ms-1" :class="buttonClass">
+                Cancel
+            </button>
+            <project-name-check-message :check-result="checkResult"></project-name-check-message>
+        </template>
+    </div>
 </template>
 <script lang="ts">
 import { VBTooltip } from "bootstrap-vue-3";
-import { defineComponent } from "vue";
+import {defineComponent} from "vue";
 import { mapActions, mapGetters } from "vuex";
 import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessage.vue";
 import { ProjectNameCheckResult } from "@/types";
@@ -76,6 +78,9 @@ export default defineComponent({
             this.editingProjectName = true;
             this.checkResult = ProjectNameCheckResult.Unchanged;
             this.inputText = this.projectName;
+            this.$nextTick(() => {
+                (this.$refs.renameProject as HTMLInputElement).focus();
+            });
         },
         cancelEditProjectName() {
             this.editingProjectName = false;
@@ -92,6 +97,10 @@ export default defineComponent({
 });
 </script>
 <style scoped>
+.edit-project-name {
+    height: 2em;
+}
+
 .edit-icon {
     color: #a1abb3;
     margin-left: 0.3em;

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -17,7 +17,11 @@
                v-on:keyup.enter="saveProjectName"
                v-model="inputModel"
                />
-        <button @click="saveProjectName" id="save-project-name" class="btn ms-2" :class="buttonClass" :disabled="!canSave">
+        <button @click="saveProjectName"
+                id="save-project-name"
+                class="btn ms-2"
+                :class="buttonClass"
+                :disabled="!canSave">
             Save
         </button>
         <button @click="cancelEditProjectName" id="cancel-project-name" class="btn ms-1" :class="buttonClass">
@@ -40,7 +44,7 @@ export default defineComponent({
         "b-tooltip": VBTooltip
     },
     props: {
-        projectId: String,
+        projectId: { type: String, required: true },
         projectName: { type: String, required: true },
         buttonClass: String
     },

--- a/app/client/src/components/projects/EditProjectName.vue
+++ b/app/client/src/components/projects/EditProjectName.vue
@@ -53,7 +53,7 @@ export default defineComponent({
     },
     computed: {
         canSave() {
-            return this.checkResult === ProjectNameCheckResult.OK || this.checkResult === ProjectNameCheckResult.Unchanged;
+            return [ProjectNameCheckResult.OK, ProjectNameCheckResult.Unchanged].includes(this.checkResult);
         },
         inputModel: {
             get() {
@@ -79,7 +79,7 @@ export default defineComponent({
         saveProjectName() {
             if (this.canSave) {
                 if (this.checkResult !== ProjectNameCheckResult.Unchanged) {
-                    this.renameProject({ projectId: this.projectId, name: this.inputText });
+                    this.renameProject({ projectId: this.projectId, name: this.inputText.trim() });
                 }
                 this.editingProjectName = false;
             }

--- a/app/client/src/components/projects/ProjectNameCheckMessage.vue
+++ b/app/client/src/components/projects/ProjectNameCheckMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="small text-danger">
+    <div class="text-danger message">
         {{ message }}
     </div>
 </template>
@@ -22,3 +22,10 @@ const message = computed(() => {
     }
 });
 </script>
+<style scoped>
+.message {
+    height: 1em;
+    font-size: small;
+    margin-bottom: 0.7em;
+}
+</style>

--- a/app/client/src/components/projects/ProjectNameCheckMessage.vue
+++ b/app/client/src/components/projects/ProjectNameCheckMessage.vue
@@ -1,0 +1,24 @@
+<template>
+    <div class="small text-danger">
+        {{ message }}
+    </div>
+</template>
+<script setup lang="ts">
+import { computed, PropType, defineProps } from "vue";
+import { ProjectNameCheckResult } from "@/types";
+
+const props = defineProps({
+    checkResult: Number as PropType<ProjectNameCheckResult>
+});
+
+const message = computed(() => {
+    switch (props.checkResult) {
+    case ProjectNameCheckResult.Duplicate:
+        return "Name already exists";
+    case ProjectNameCheckResult.Empty:
+        return "Name cannot be empty";
+    default:
+        return "";
+    }
+});
+</script>

--- a/app/client/src/components/projects/SavedProjects.vue
+++ b/app/client/src/components/projects/SavedProjects.vue
@@ -10,7 +10,7 @@
           <div v-for="project in savedProjects" :key="project.hash" class="row saved-project-row">
               <div class="col-6 saved-project-name">
                   <edit-project-name :project-name="project.name" :project-id="project.id" :button-class="'btn-sm'">
-                      <button class="clickable brand-text"
+                      <button class="clickable brand-text saved-project-name"
                               @click="loadProject(project)"
                               @keydown="loadProjectFromKey(project, $event.keyCode)">
                           {{ project.name }}

--- a/app/client/src/store/actions.ts
+++ b/app/client/src/store/actions.ts
@@ -71,7 +71,8 @@ export default {
             loadingProject: true,
             projectId: project.id,
             projectHash: project.hash,
-            projectName: project.name
+            projectName: project.name,
+            savedProjects: state.savedProjects
         });
         commit("addLoadingProjectMessage", "Fetching sketches");
         await api(context)

--- a/app/client/src/store/getters.ts
+++ b/app/client/src/store/getters.ts
@@ -1,7 +1,6 @@
-import { AnalysisType, ProjectNameCheckResult, SavedProject } from "@/types";
+import { AnalysisType, ProjectNameCheckResult } from "@/types";
 import { Getter, GetterTree } from "vuex";
 import { RootState } from "@/store/state";
-import store from "@/store/index";
 
 export enum BeebopGetter {
   analysisProgress = "analysisProgress",

--- a/app/client/src/store/getters.ts
+++ b/app/client/src/store/getters.ts
@@ -1,14 +1,17 @@
-import { AnalysisType } from "@/types";
+import { AnalysisType, ProjectNameCheckResult, SavedProject } from "@/types";
 import { Getter, GetterTree } from "vuex";
 import { RootState } from "@/store/state";
+import store from "@/store/index";
 
 export enum BeebopGetter {
   analysisProgress = "analysisProgress",
-  uniqueClusters = "uniqueClusters"
+  uniqueClusters = "uniqueClusters",
+  checkProjectName = "checkProjectName"
 }
 
 export interface BeebopGetters {
-  [BeebopGetter.analysisProgress]: Getter<RootState, RootState>
+  [BeebopGetter.analysisProgress]: Getter<RootState, RootState>,
+  [BeebopGetter.checkProjectName]: Getter<RootState, RootState>
 }
 
 export const getters: BeebopGetters & GetterTree<RootState, RootState> = {
@@ -33,5 +36,22 @@ export const getters: BeebopGetters & GetterTree<RootState, RootState> = {
             clusters.push(state.results.perIsolate[element].cluster as number);
         });
         return [...new Set(clusters)].sort((a, b) => a - b);
+    },
+
+    [BeebopGetter.checkProjectName]: (
+        state: RootState
+    ): ((name: string, oldName?: string) => ProjectNameCheckResult) => {
+        return (name: string, oldName?: string) => {
+            if (name.trim() === "") {
+                return ProjectNameCheckResult.Empty;
+            }
+            if (oldName && oldName === name) {
+                return ProjectNameCheckResult.Unchanged;
+            }
+            if (state.savedProjects.find((p) => p.name === name)) {
+                return ProjectNameCheckResult.Duplicate;
+            }
+            return ProjectNameCheckResult.OK;
+        };
     }
 };

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -96,3 +96,10 @@ export interface ProjectResponse {
     samples: Isolate[],
     status: AnalysisStatus
 }
+
+export enum ProjectNameCheckResult {
+    OK,
+    Duplicate,
+    Empty,
+    Unchanged
+}

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -1,4 +1,6 @@
 import { RootState } from "@/store/state";
+import {SavedProject} from "@/types";
+import store from "@/store";
 
 export const emptyState = (): RootState => ({
     errors: [],

--- a/app/client/src/utils.ts
+++ b/app/client/src/utils.ts
@@ -1,6 +1,4 @@
 import { RootState } from "@/store/state";
-import {SavedProject} from "@/types";
-import store from "@/store";
 
 export const emptyState = (): RootState => ({
     errors: [],

--- a/app/client/src/views/ProjectView.vue
+++ b/app/client/src/views/ProjectView.vue
@@ -6,7 +6,6 @@
       </div>
       <div class="overview">
         <h4 class="left">
-            Project:
             <edit-project-name :project-id="projectId" :project-name="projectName" :button-class="'btn-standard'">
                 {{ projectName }}
             </edit-project-name>

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -40,7 +40,7 @@ test.describe("Logged in Tests", () => {
     test("should display dropzone in Project view", async ({ page }) => {
         await createProject("test project", page);
         await expect(page.locator(".dropzone")).toBeVisible();
-        await expect(page.locator("h4")).toContainText("Project: test project");
+        await expect(page.locator("h4")).toContainText("test project");
     });
 
     test("should redirect from project page to home page if name has not been provided", async ({ page }) => {
@@ -134,7 +134,7 @@ test.describe("Logged in Tests", () => {
         await page.click("h4 i");
         await page.fill("h4 input", "new project name");
         await page.click("#save-project-name");
-        expect(await page.innerText("h4")).toBe("Project: new project name");
+        expect(await page.innerText("h4")).toBe("new project name");
 
         // browse back to Home page and check project has been renamed
         await page.goto(config.clientUrl());

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -161,14 +161,14 @@ test.describe("Logged in Tests", () => {
         await createProject("name test 2", page);
         await page.goto(config.clientUrl());
 
-        // Click edit icon for first project and confirm editing
+        // Click edit icon for most recent project and confirm editing
         await page.click(":nth-match(.edit-project-name i, 1)");
         await expect(page.locator(".edit-project-name input")).toHaveCount(1);
 
-        // Click edit icon for next project and confirm editing one project name only
-        const secondProjectName = await page.locator(":nth-match(.saved-project-name, 2)").innerText();
-        await page.click(":nth-match(.edit-project-name i, 2)");
+        // Click edit icon for second most recent project and confirm editing one project name only
+        const projectName = await page.locator(":nth-match(.saved-project-name, 2)").innerText();
+        await page.click(":nth-match(.edit-project-name i, 1)");
         await expect(page.locator(".edit-project-name input")).toHaveCount(1);
-        await expect(page.locator(".edit-project-name input")).toHaveValue(secondProjectName);
+        await expect(page.locator(".edit-project-name input")).toHaveValue(projectName);
     });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -152,4 +152,21 @@ test.describe("Logged in Tests", () => {
         await page.click("#save-project-name");
         expect(await page.innerText(".saved-project-name")).toBe(newProjectName);
     });
+
+    test("can only edit one project name at a time in Home page", async ({ page }) => {
+        await createProject("name test 1", page);
+        await page.goto(config.clientUrl());
+        await createProject("name test 2", page);
+        await page.goto(config.clientUrl());
+
+        // Click edit icon for first project and confirm editing
+        await page.click(":nth-match(.edit-project-name i, 1)");
+        await expect(page.locator(".edit-project-name input")).toHaveCount(1);
+
+        // Click edit icon for next project and confirm editing one project name only
+        const secondProjectName = await page.locator(":nth-match(.saved-project-name, 2)").innerText();
+        await page.click(":nth-match(.edit-project-name i, 2)");
+        await expect(page.locator(".edit-project-name input")).toHaveCount(1);
+        await expect(page.locator(".edit-project-name input")).toHaveValue(secondProjectName);
+    });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -142,7 +142,8 @@ test.describe("Logged in Tests", () => {
 
         // browse back to Home page and check project has been renamed
         await page.goto(config.clientUrl());
-        expect(await page.innerText(".saved-project-row .saved-project-name")).toBe("new project name");
+        expect(await page.innerText(":nth-match(.saved-project-row .saved-project-name, 1)"))
+            .toBe("new project name");
 
         // rename project in Home view
         await page.click(".saved-project-name i");

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -111,16 +111,16 @@ test.describe("Logged in Tests", () => {
         await expect(page.locator("#cy canvas")).toHaveCount(3);
         // can browse back to Home page and see new project in history
         await page.goto(config.clientUrl());
-        await expect(await page.locator(".saved-project-row .saved-project-name").last())
+        await expect(await page.locator(".saved-project-row .saved-project-name").first())
             .toHaveText("test project", { timeout });
-        expect(await (await page.locator(".saved-project-row .saved-project-date").last()).innerText())
+        expect(await (await page.locator(".saved-project-row .saved-project-date").first()).innerText())
             .toMatch(/^[0-3][0-9]\/[0-1][0-9]\/20[2-9][0-9] [0-2][0-9]:[0-5][0-9]$/);
         const lastProjectIndex = await page.locator(".saved-project-row").count();
         // can create a new empty project
         await createProject("another test project", page);
-        // can browse back to Home page ad load previous project
+        // can browse back to Home page and load previous project
         await page.goto(config.clientUrl());
-        await page.click(`:nth-match(.saved-project-row button, ${lastProjectIndex})`);
+        await page.click(":nth-match(.saved-project-row button, 2)");
         await expect(page.locator(":nth-match(.tab-content tr, 1)"))
             .toContainText(["6930_8_13.fa", "✔", "PCETE SXT"], { timeout });
         await expect(page.locator(":nth-match(.tab-content tr, 2)"))
@@ -146,8 +146,10 @@ test.describe("Logged in Tests", () => {
 
         // rename project in Home view
         await page.click(".saved-project-name i");
-        await page.fill(".saved-project-name input", "another new project name");
+        const newProjectName = `another new project name ${Date.now()}`;
+        await page.fill(".saved-project-name input", newProjectName);
+        await expect(page.locator("#save-project-name")).toBeEnabled();
         await page.click("#save-project-name");
-        expect(await page.innerText(".saved-project-name")).toBe("another new project name");
+        expect(await page.innerText(".saved-project-name")).toBe(newProjectName);
     });
 });

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -132,6 +132,10 @@ test.describe("Logged in Tests", () => {
         // rename project in Project view
         await createProject("old project name", page);
         await page.click("h4 i");
+        // should be prevented from saving empty project name
+        await page.fill("h4 input", "");
+        await expect(page.locator("#save-project-name")).not.toBeEnabled();
+        await expect(page.locator(".message")).toHaveText("Name cannot be empty");
         await page.fill("h4 input", "new project name");
         await page.click("#save-project-name");
         expect(await page.innerText("h4")).toBe("new project name");

--- a/app/client/tests/e2e/LoggedIn.spec.ts
+++ b/app/client/tests/e2e/LoggedIn.spec.ts
@@ -7,7 +7,7 @@ import config from "../../src/settings/development/config";
 import PlaywrightConfig from "../../playwright.config";
 
 const createProject = async (projectName: string, page: Page) => {
-    await page.fill("input#create-project-name", "test project");
+    await page.fill("input#create-project-name", projectName);
     await page.click("button#create-project-btn");
     expect(await page.locator("#no-results").innerText()).toBe("No data uploaded yet");
 };
@@ -136,22 +136,23 @@ test.describe("Logged in Tests", () => {
         await page.fill("h4 input", "");
         await expect(page.locator("#save-project-name")).not.toBeEnabled();
         await expect(page.locator(".message")).toHaveText("Name cannot be empty");
-        await page.fill("h4 input", "new project name");
+        const newProjectName = `new project name ${Date.now()}`;
+        await page.fill("h4 input", newProjectName);
         await page.click("#save-project-name");
-        expect(await page.innerText("h4")).toBe("new project name");
+        await expect(page.locator("h4")).toHaveText(newProjectName, { timeout });
 
         // browse back to Home page and check project has been renamed
         await page.goto(config.clientUrl());
         expect(await page.innerText(":nth-match(.saved-project-row .saved-project-name, 1)"))
-            .toBe("new project name");
+            .toBe(newProjectName);
 
         // rename project in Home view
         await page.click(".saved-project-name i");
-        const newProjectName = `another new project name ${Date.now()}`;
-        await page.fill(".saved-project-name input", newProjectName);
+        const anotherNewProjectName = `another new project name ${Date.now()}`;
+        await page.fill(".saved-project-name input", anotherNewProjectName);
         await expect(page.locator("#save-project-name")).toBeEnabled();
         await page.click("#save-project-name");
-        expect(await page.innerText(".saved-project-name")).toBe(newProjectName);
+        expect(await page.innerText(".saved-project-name")).toBe(anotherNewProjectName);
     });
 
     test("can only edit one project name at a time in Home page", async ({ page }) => {

--- a/app/client/tests/unit/components/projects/EditProjectName.spec.ts
+++ b/app/client/tests/unit/components/projects/EditProjectName.spec.ts
@@ -82,7 +82,6 @@ describe("EditProjectName", () => {
         await nextTick();
         const input = wrapper.find("input").element;
         expect(input).toBe(document.activeElement);
-
     });
 
     it("clicking Cancel button stops editing", async () => {

--- a/app/client/tests/unit/components/projects/EditProjectName.spec.ts
+++ b/app/client/tests/unit/components/projects/EditProjectName.spec.ts
@@ -109,7 +109,7 @@ describe("EditProjectName", () => {
         const wrapper = getWrapper();
         await wrapper.setData({ editingProjectName: true });
         await wrapper.find("input").setValue("new project name");
-        await wrapper.find("button#save-project-name").trigger("click");
+        await wrapper.find("button#save-project-name").trigger("mousedown");
         expectSavedProject(wrapper);
     });
 
@@ -145,7 +145,7 @@ describe("EditProjectName", () => {
         const wrapper = getWrapper();
         await wrapper.setData({ editingProjectName: true });
         await wrapper.find("input").setValue("old project name");
-        await wrapper.find("button#save-project-name").trigger("click");
+        await wrapper.find("button#save-project-name").trigger("mousedown");
         expect(mockRenameProject).not.toHaveBeenCalled();
         // stops editing
         expect(wrapper.vm.$data.editingProjectName).toBe(false);
@@ -156,7 +156,7 @@ describe("EditProjectName", () => {
         const wrapper = getWrapper();
         await wrapper.setData({ editingProjectName: true });
         await wrapper.find("input").setValue("  new project name ");
-        await wrapper.find("button#save-project-name").trigger("click");
+        await wrapper.find("button#save-project-name").trigger("mousedown");
         expectSavedProject(wrapper);
     });
 

--- a/app/client/tests/unit/components/projects/EditProjectName.spec.ts
+++ b/app/client/tests/unit/components/projects/EditProjectName.spec.ts
@@ -6,6 +6,7 @@ import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessa
 import { ProjectNameCheckResult } from "@/types";
 import { getters } from "@/store/getters";
 import { mockRootState } from "../../../mocks";
+import {nextTick} from "vue";
 
 describe("EditProjectName", () => {
     const mockRenameProject = jest.fn();
@@ -33,7 +34,8 @@ describe("EditProjectName", () => {
             },
             global: {
                 plugins: [store]
-            }
+            },
+            attachTo: document.body
         });
     };
 
@@ -76,6 +78,11 @@ describe("EditProjectName", () => {
         expect(wrapper.findComponent(ProjectNameCheckMessage).props("checkResult"))
             .toBe(ProjectNameCheckResult.Unchanged);
         expect(wrapper.find("button#save-project-name").exists()).toBe(true);
+
+        await nextTick();
+        const input = wrapper.find("input").element;
+        expect(input).toBe(document.activeElement);
+
     });
 
     it("clicking Cancel button stops editing", async () => {
@@ -152,5 +159,14 @@ describe("EditProjectName", () => {
         await wrapper.find("input").setValue("  new project name ");
         await wrapper.find("button#save-project-name").trigger("click");
         expectSavedProject(wrapper);
+    });
+
+    it("losing focus from enclosing div cancels edit", async () => {
+        const wrapper = getWrapper();
+        await wrapper.setData({ editingProjectName: true });
+        await wrapper.find("div.edit-project-name").trigger("focusout");
+        expect(wrapper.vm.$data.editingProjectName).toBe(false);
+        expect(wrapper.find("span#test-slot").exists()).toBe(true);
+        expect(wrapper.find("i").exists()).toBe(true);
     });
 });

--- a/app/client/tests/unit/components/projects/EditProjectName.spec.ts
+++ b/app/client/tests/unit/components/projects/EditProjectName.spec.ts
@@ -2,16 +2,25 @@ import Vuex from "vuex";
 import { RootState } from "@/store/state";
 import { mount, VueWrapper } from "@vue/test-utils";
 import EditProjectName from "@/components/projects/EditProjectName.vue";
+import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessage.vue";
+import { ProjectNameCheckResult } from "@/types";
+import { getters } from "@/store/getters";
 import { mockRootState } from "../../../mocks";
 
 describe("EditProjectName", () => {
     const mockRenameProject = jest.fn();
     const getWrapper = () => {
         const store = new Vuex.Store<RootState>({
-            state: mockRootState(),
+            state: mockRootState({
+                savedProjects: [
+                    { id: "1", name: "existing project 1" },
+                    { id: "2", name: "existing project 2" }
+                ] as any
+            }),
             actions: {
                 renameProject: mockRenameProject
-            }
+            },
+            getters
         });
         return mount(EditProjectName, {
             props: {
@@ -42,7 +51,11 @@ describe("EditProjectName", () => {
 
     it("renders as expected when editing", async () => {
         const wrapper = getWrapper();
-        await wrapper.setData({ editingProjectName: true });
+        await wrapper.setData({
+            editingProjectName: true,
+            inputText: "old project name",
+            checkResult: ProjectNameCheckResult.Unchanged
+        });
         expect(wrapper.find("span#test-slot").exists()).toBe(false);
         expect(wrapper.find("i").exists()).toBe(false);
         expect((wrapper.find("input").element as HTMLInputElement).value).toBe("old project name");
@@ -50,13 +63,18 @@ describe("EditProjectName", () => {
         expect(wrapper.find("button#save-project-name").classes()).toContain("btn-sm");
         expect(wrapper.find("button#cancel-project-name").text()).toBe("Cancel");
         expect(wrapper.find("button#cancel-project-name").classes()).toContain("btn-sm");
+        expect(wrapper.findComponent(ProjectNameCheckMessage).props("checkResult"))
+            .toBe(ProjectNameCheckResult.Unchanged);
     });
 
-    it("clicking edit icon enables editing", async () => {
+    it("clicking edit icon enables editing and sets data", async () => {
         const wrapper = getWrapper();
         await wrapper.find("i.edit-icon").trigger("click");
         expect(wrapper.vm.$data.editingProjectName).toBe(true);
         expect(wrapper.find("input").exists()).toBe(true);
+        expect((wrapper.find("input").element as HTMLInputElement).value).toBe("old project name");
+        expect(wrapper.findComponent(ProjectNameCheckMessage).props("checkResult"))
+            .toBe(ProjectNameCheckResult.Unchanged);
         expect(wrapper.find("button#save-project-name").exists()).toBe(true);
     });
 
@@ -94,6 +112,45 @@ describe("EditProjectName", () => {
         await wrapper.setData({ editingProjectName: true });
         await wrapper.find("input").setValue("new project name");
         await wrapper.find("input").trigger("keyup.enter");
+        expectSavedProject(wrapper);
+    });
+
+    it("changing input value updates project name check result and Save button", async () => {
+        const wrapper = getWrapper();
+
+        const expectComponentValuesForInputText = async (
+            inputText: string,
+            checkResult: ProjectNameCheckResult,
+            saveButtonEnabled: boolean) => {
+            await wrapper.find("input").setValue(inputText);
+            expect(wrapper.findComponent(ProjectNameCheckMessage).props("checkResult")).toBe(checkResult);
+            expect((wrapper.find("button#save-project-name").element as HTMLButtonElement).disabled)
+                .toBe(!saveButtonEnabled);
+        };
+
+        await wrapper.find("i.edit-icon").trigger("click");
+        await expectComponentValuesForInputText("", ProjectNameCheckResult.Empty, false);
+        await expectComponentValuesForInputText("existing project 2", ProjectNameCheckResult.Duplicate, false);
+        await expectComponentValuesForInputText("new name", ProjectNameCheckResult.OK, true);
+        await expectComponentValuesForInputText("old project name", ProjectNameCheckResult.Unchanged, true);
+    });
+
+    it("clicking Save button does not invoke Save action if name is unchanged", async () => {
+        const wrapper = getWrapper();
+        await wrapper.setData({ editingProjectName: true });
+        await wrapper.find("input").setValue("old project name");
+        await wrapper.find("button#save-project-name").trigger("click");
+        expect(mockRenameProject).not.toHaveBeenCalled();
+        // stops editing
+        expect(wrapper.vm.$data.editingProjectName).toBe(false);
+        expect(wrapper.find("span#test-slot").exists()).toBe(true);
+    });
+
+    it("trims name on save", async () => {
+        const wrapper = getWrapper();
+        await wrapper.setData({ editingProjectName: true });
+        await wrapper.find("input").setValue("  new project name ");
+        await wrapper.find("button#save-project-name").trigger("click");
         expectSavedProject(wrapper);
     });
 });

--- a/app/client/tests/unit/components/projects/ProjectNameCheckMessage.spec.ts
+++ b/app/client/tests/unit/components/projects/ProjectNameCheckMessage.spec.ts
@@ -1,0 +1,20 @@
+import { ProjectNameCheckResult } from "@/types";
+import { mount } from "@vue/test-utils";
+import ProjectNameCheckMessage from "@/components/projects/ProjectNameCheckMessage.vue";
+
+describe("ProjectNameCheckMessage", () => {
+    const getWrapper = (checkResult: ProjectNameCheckResult) => {
+        return mount(ProjectNameCheckMessage, { props: { checkResult } });
+    };
+
+    it("renders as expected", () => {
+        let wrapper = getWrapper(ProjectNameCheckResult.OK);
+        expect(wrapper.text()).toBe("");
+        wrapper = getWrapper(ProjectNameCheckResult.Unchanged);
+        expect(wrapper.text()).toBe("");
+        wrapper = getWrapper(ProjectNameCheckResult.Empty);
+        expect(wrapper.text()).toBe("Name cannot be empty");
+        wrapper = getWrapper(ProjectNameCheckResult.Duplicate);
+        expect(wrapper.text()).toBe("Name already exists");
+    });
+});

--- a/app/client/tests/unit/store/actions.spec.ts
+++ b/app/client/tests/unit/store/actions.spec.ts
@@ -547,14 +547,15 @@ describe("Actions", () => {
     it("loadProject commits error on error response", async () => {
         const commit = jest.fn();
         const dispatch = jest.fn();
-        const state = mockRootState();
         const savedProject = {
             hash: "123",
             id: "abc",
             name: "test project",
             timestamp: 1687879927224
         };
-        const projectResponse = { test: "value" };
+        const state = mockRootState({
+            savedProjects: [savedProject]
+        });
         const url = `${serverUrl}/project/abc`;
         mockAxios.onGet(url).reply(500, responseError({ error: "test error" }));
         await actions.loadProject({ commit, dispatch, state } as any, savedProject);
@@ -572,6 +573,7 @@ describe("Actions", () => {
         expect(commit.mock.calls[4][1]).toBe("Loading complete");
         expect(commit.mock.calls[5][0]).toBe("setLoadingProject");
         expect(commit.mock.calls[5][1]).toBe(false);
+        expect(state.savedProjects).toStrictEqual([savedProject]);
     });
 
     it("postAMR posts amr data", async () => {

--- a/app/client/tests/unit/store/getters.spec.ts
+++ b/app/client/tests/unit/store/getters.spec.ts
@@ -1,5 +1,6 @@
 import { getters } from "@/store/getters";
 import { mockRootState } from "../../mocks";
+import {ProjectNameCheckResult} from "@/types";
 
 describe("getters", () => {
     it("calculates analysisProgress", () => {
@@ -50,5 +51,35 @@ describe("getters", () => {
             state,
             "uniqueClusters"
         )).toStrictEqual([2, 4, 7, 31]);
+    });
+
+    it("checkProjectName returns Empty", () => {
+        const check = (getters.checkProjectName as any)(mockRootState());
+        expect(check(" ")).toBe(ProjectNameCheckResult.Empty);
+    });
+
+    it("checkProjectName returns Unchanged", () => {
+        const check = (getters.checkProjectName as any)(mockRootState());
+        expect(check("project 1", "project 1")).toBe(ProjectNameCheckResult.Unchanged);
+    });
+
+    it("checkProjectName returns Duplicate", () => {
+        const check = (getters.checkProjectName as any)(mockRootState({
+            savedProjects: [
+                { id: "1", name: "project 1" },
+                { id: "2", name: "project 2" }
+            ] as any
+        }));
+        expect(check("project 2", "project 3")).toBe(ProjectNameCheckResult.Duplicate);
+    });
+
+    it("checkProjectName returns OK", () => {
+        const check = (getters.checkProjectName as any)(mockRootState({
+            savedProjects: [
+                { id: "1", name: "project 1" },
+                { id: "2", name: "project 2" }
+            ] as any
+        }));
+        expect(check("project 4", "project 3")).toBe(ProjectNameCheckResult.OK);
     });
 });

--- a/app/client/tests/unit/views/ProjectView.spec.ts
+++ b/app/client/tests/unit/views/ProjectView.spec.ts
@@ -55,7 +55,7 @@ describe("Project", () => {
             }
         });
 
-        expect(wrapper.find("h4").text()).toBe("Project: test project");
+        expect(wrapper.find("h4").text()).toBe("test project");
         expect(wrapper.findComponent(EditProjectName).props()).toStrictEqual({
             projectId: "ABC-123",
             projectName: "test project",


### PR DESCRIPTION
This branch adds some front end validation when user edits project name - change will not be allowed to name which is empty or whitespace, or if another of the user's projects has the same name. The same rules will be added to Create Project in a separate ticket. 

Key changes:
- added a getter to do the actual check, as we'll also want to use this for creating new projects and an enum for the possible check results. 
- updated `EditProjectName` component to check candidate project name on each key change, prevent saving when validation fails and show an appropriate message (implemented as a component, which will also be used in the Create Project case). To avoid user alarm, there is no error message or button disable if the name is identical to the current name, but no action will be invoked if click 'Save' at this point. 
- Removed 'Project' prefix from Project page header - I don't think it was useful, and it was causing formatting headaches when editing!
- Includes SavedProjects when state is reset on Project load, so that they are available for checking duplicate names

Adding the no duplicates requirement has impacted the e2e tests - I have modified where required, and will eventually need to update others, once create project prevents duplicates too..