### PR TITLE
Bacpop-163 Error handle + delete sample

### DIFF
--- a/app/client-v2/src/__tests__/components/ProjectView/AmrColumn.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/AmrColumn.spec.ts
@@ -6,6 +6,9 @@ import { render, screen } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
 import Tooltip from "primevue/tooltip";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 const renderComponent = (amr?: AMR) => {
   return render(AmrColumnVue, {
     props: {

--- a/app/client-v2/src/__tests__/components/ProjectView/MicroReactColumn.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/MicroReactColumn.spec.ts
@@ -14,7 +14,9 @@ const mockUseMicroreact = {
   onMicroReactVisit: vitest.fn(),
   saveMicroreactToken: vitest.fn()
 };
-
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 vitest.mock("@/composables/useMicroreact", () => ({
   useMicroreact: () => mockUseMicroreact
 }));

--- a/app/client-v2/src/__tests__/components/ProjectView/NetworkGraph.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/NetworkGraph.spec.ts
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
 import Tooltip from "primevue/tooltip";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 describe("NetworkGraph", () => {
   it("should render graph and be able to go from fullscreen and close fullscreen mode", async () => {
     render(NetworkGraph, {

--- a/app/client-v2/src/__tests__/components/ProjectView/NetworkTab.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/NetworkTab.spec.ts
@@ -8,6 +8,9 @@ import { HttpResponse, http } from "msw";
 import PrimeVue from "primevue/config";
 import { defineComponent } from "vue";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 describe("Network Tabs", () => {
   it("should render network graphs with props for each cluster returned from api", async () => {
     render(NetworkTab, {

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectDataTable.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectDataTable.spec.ts
@@ -4,6 +4,9 @@ import { createTestingPinia } from "@pinia/testing";
 import { render, screen } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 describe("Project data table", () => {
   beforeEach(() => {
     render(ProjectDataTableVue, {

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPage.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPage.spec.ts
@@ -3,6 +3,8 @@ import { useProjectStore } from "@/stores/projectStore";
 import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent } from "vue";
+import ToastService from "primevue/toastservice";
+import PrimeVue from "primevue/config";
 
 vitest.mock("vue-router", () => ({
   useRoute: vitest.fn(() => ({
@@ -34,7 +36,7 @@ describe("Project Page", () => {
     store.startedRun = true;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia],
+        plugins: [testPinia, PrimeVue, ToastService],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -57,7 +59,7 @@ describe("Project Page", () => {
     store.startedRun = false;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia],
+        plugins: [testPinia, PrimeVue, ToastService],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -75,7 +77,7 @@ describe("Project Page", () => {
     store.getProject = vitest.fn().mockResolvedValue("error fetching projects");
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia],
+        plugins: [testPinia, ToastService],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -94,7 +96,7 @@ describe("Project Page", () => {
     store.isProjectComplete = true;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia],
+        plugins: [testPinia, PrimeVue, ToastService],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -109,7 +111,7 @@ describe("Project Page", () => {
   it("should call stopPollingStatus on unmount", async () => {
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [createTestingPinia()],
+        plugins: [createTestingPinia(), PrimeVue, ToastService],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPage.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPage.spec.ts
@@ -3,9 +3,11 @@ import { useProjectStore } from "@/stores/projectStore";
 import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent } from "vue";
-import ToastService from "primevue/toastservice";
 import PrimeVue from "primevue/config";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 vitest.mock("vue-router", () => ({
   useRoute: vitest.fn(() => ({
     params: {
@@ -36,7 +38,7 @@ describe("Project Page", () => {
     store.startedRun = true;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia, PrimeVue, ToastService],
+        plugins: [PrimeVue, testPinia],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -59,7 +61,7 @@ describe("Project Page", () => {
     store.startedRun = false;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia, PrimeVue, ToastService],
+        plugins: [PrimeVue, testPinia],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -77,7 +79,7 @@ describe("Project Page", () => {
     store.getProject = vitest.fn().mockResolvedValue("error fetching projects");
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia, ToastService],
+        plugins: [PrimeVue, testPinia],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -96,7 +98,7 @@ describe("Project Page", () => {
     store.isProjectComplete = true;
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [testPinia, PrimeVue, ToastService],
+        plugins: [PrimeVue, testPinia],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject
@@ -111,7 +113,7 @@ describe("Project Page", () => {
   it("should call stopPollingStatus on unmount", async () => {
     const wrapper = mount(AsyncProjectPage, {
       global: {
-        plugins: [createTestingPinia(), PrimeVue, ToastService],
+        plugins: [PrimeVue, createTestingPinia()],
         stubs: {
           ProjectPostRun: stubRunProject,
           ProjectPreRun: stubNotRunProject

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
@@ -7,6 +7,9 @@ import { render, screen, waitFor } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
 import Tooltip from "primevue/tooltip";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 describe("RunProject", () => {
   it("should render progress bar if progress is not 100%", () => {
     const testingPinia = createTestingPinia();

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPreRun.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPreRun.spec.ts
@@ -1,17 +1,18 @@
-import NotRunProjectVue from "@/components/ProjectView/ProjectPreRun.vue";
+import ProjectPreRun from "@/components/ProjectView/ProjectPreRun.vue";
 import { MOCK_PROJECT_SAMPLES_BEFORE_RUN } from "@/mocks/mockObjects";
 import { useProjectStore } from "@/stores/projectStore";
 import { createTestingPinia } from "@pinia/testing";
 import userEvent from "@testing-library/user-event";
 import { fireEvent, render, screen, waitFor } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
+import Tooltip from "primevue/tooltip";
 
 vitest.mock("primevue/usetoast", () => ({
   useToast: vitest.fn()
 }));
 describe("ProjectView ", () => {
   it("should render drag and drop section no files uploaded", () => {
-    render(NotRunProjectVue, {
+    render(ProjectPreRun, {
       global: {
         plugins: [
           createTestingPinia({
@@ -36,7 +37,7 @@ describe("ProjectView ", () => {
     // @ts-expect-error: Getter is read only
     store.isReadyToRun = true;
     store.project.samples = [];
-    render(NotRunProjectVue, {
+    render(ProjectPreRun, {
       global: {
         plugins: [testPinia, PrimeVue]
       }
@@ -52,7 +53,7 @@ describe("ProjectView ", () => {
     store.project.samples = [];
     // @ts-expect-error: Getter is read only
     store.isReadyToRun = false;
-    render(NotRunProjectVue, {
+    render(ProjectPreRun, {
       global: {
         plugins: [testPinia, PrimeVue]
       }
@@ -61,7 +62,7 @@ describe("ProjectView ", () => {
     expect(screen.getByRole("button", { name: /run analysis/i })).toBeDisabled();
   });
   it("should render data table if file samples uploaded", () => {
-    render(NotRunProjectVue, {
+    render(ProjectPreRun, {
       global: {
         plugins: [
           createTestingPinia({
@@ -88,7 +89,7 @@ describe("ProjectView ", () => {
 
   it("should call store.onFilesUpload on files uploaded", async () => {
     const mockFile = { name: "sample1.fasta", text: () => Promise.resolve("sample1") } as File;
-    const { container } = render(NotRunProjectVue, {
+    const { container } = render(ProjectPreRun, {
       global: {
         plugins: [
           createTestingPinia({
@@ -111,6 +112,36 @@ describe("ProjectView ", () => {
 
     await waitFor(() => {
       expect(store.onFilesUpload).toHaveBeenCalledWith([mockFile]);
+    });
+  });
+
+  it("should render button to remove uploaded files and call store.removeUploadedFile on click", async () => {
+    render(ProjectPreRun, {
+      global: {
+        plugins: [
+          PrimeVue,
+          createTestingPinia({
+            initialState: {
+              project: {
+                project: {
+                  samples: MOCK_PROJECT_SAMPLES_BEFORE_RUN
+                }
+              }
+            }
+          })
+        ],
+        directives: {
+          tooltip: Tooltip
+        }
+      }
+    });
+    const store = useProjectStore();
+
+    const removeButton = screen.getAllByRole("button", { name: /remove/i })[1];
+    await userEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(store.removeUploadedFile).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPreRun.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPreRun.spec.ts
@@ -6,6 +6,9 @@ import userEvent from "@testing-library/user-event";
 import { fireEvent, render, screen, waitFor } from "@testing-library/vue";
 import PrimeVue from "primevue/config";
 
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn()
+}));
 describe("ProjectView ", () => {
   it("should render drag and drop section no files uploaded", () => {
     render(NotRunProjectVue, {

--- a/app/client-v2/src/__tests__/stores/projectStore.spec.ts
+++ b/app/client-v2/src/__tests__/stores/projectStore.spec.ts
@@ -194,10 +194,11 @@ describe("projectStore", () => {
 
       expect(store.project.samples[0].sketch).toEqual({ filename: "sample1.fasta", md5: "sample1-md5" });
     });
-    it("should remove sample from fileSamples when handleWorkerResponse fails", async () => {
+    it("should remove sample from fileSamples when handleWorkerResponse fails & call showErrorToast", async () => {
       const store = useProjectStore();
       store.project.id = "1";
       store.project.samples = [...mockFilesWithHashes];
+      store.showErrorToast = vitest.fn();
       const eventData = {
         hash: mockFilesWithHashes[0].hash,
         result: JSON.stringify({ Penicillin: 0.24, Chloramphenicol: 0.24 }),
@@ -212,6 +213,7 @@ describe("projectStore", () => {
       await store.handleWorkerResponse("sample1.fasta", { data: eventData } as any);
 
       expect(store.project.samples).toEqual(mockFilesWithHashes.slice(1));
+      expect(store.showErrorToast).toHaveBeenCalledWith("Ensure uploaded sample file is correct or try again later.");
     });
 
     it("should set pollingIntervalId when pollAnalysisStatus is called & not already set", async () => {
@@ -277,15 +279,19 @@ describe("projectStore", () => {
       expect(store.project.status).toEqual(MOCK_PROJECT.status);
       expect(store.stopPollingStatus).toHaveBeenCalled();
     });
-    it("should stop polling if status request fails", async () => {
+    it("should stop polling & call showErrorToast if status request fails", async () => {
       const store = useProjectStore();
       store.stopPollingStatus = vitest.fn();
+      store.showErrorToast = vitest.fn();
       server.use(http.post(statusUri, () => HttpResponse.error()));
 
       await store.getAnalysisStatus();
 
       expect(store.pollingIntervalId).toBeNull();
       expect(store.stopPollingStatus).toHaveBeenCalled();
+      expect(store.showErrorToast).toHaveBeenCalledWith(
+        "Error fetching analysis status. Try again later, or create a new project."
+      );
     });
     it("should not stop polling if status request returns incomplete status", async () => {
       const store = useProjectStore();
@@ -399,6 +405,43 @@ describe("projectStore", () => {
       await store.downloadZip(AnalysisType.MICROREACT, "GPSC1");
 
       expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it("should call toast with msg passed in when showErrorToast called", () => {
+      const store = useProjectStore();
+
+      store.showErrorToast("test-error");
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        severity: "error",
+        summary: "Error Occurred",
+        detail: "test-error",
+        life: 3000
+      });
+    });
+
+    it("should call api and remove sample from store at index when removeUploadedFile is called", async () => {
+      const store = useProjectStore();
+      store.project.samples = ["sample1", "sample2", "sample3"] as any;
+
+      await store.removeUploadedFile(2);
+
+      expect(store.project.samples).toEqual(["sample1", "sample2"]);
+    });
+    it("should call api with correct params and showErrorToast when removeUploadedFile fails", async () => {
+      const store = useProjectStore();
+      store.showErrorToast = vitest.fn();
+      store.project.samples = ["sample1", "sample2", "sample3"] as any;
+      server.use(
+        http.post(`/project/${store.project.id}/sample/${store.project.samples[2].hash}/delete`, () =>
+          HttpResponse.error()
+        )
+      );
+
+      await store.removeUploadedFile(2);
+
+      expect(store.showErrorToast).toHaveBeenCalledWith("Error removing file. Try again later.");
+      expect(store.project.samples).toEqual(["sample1", "sample2", "sample3"]);
     });
   });
 });

--- a/app/client-v2/src/__tests__/stores/projectStore.spec.ts
+++ b/app/client-v2/src/__tests__/stores/projectStore.spec.ts
@@ -9,6 +9,13 @@ import { HttpResponse, http } from "msw";
 import { createPinia, setActivePinia } from "pinia";
 import { Md5 } from "ts-md5";
 
+const mockToastAdd = vitest.fn();
+vitest.mock("primevue/usetoast", () => ({
+  useToast: vitest.fn(() => ({
+    add: mockToastAdd
+  }))
+}));
+
 describe("projectStore", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -366,7 +373,7 @@ describe("projectStore", () => {
       server.use(
         http.post(`${getApiUrl()}/downloadZip`, async ({ request }) => {
           const body = await request.json();
-          expect(body).toEqual({ type: AnalysisType.MICROREACT, cluster: 1, projectHash: store.project.hash });
+          expect(body).toEqual({ type: AnalysisType.MICROREACT, cluster: "GPSC1", projectHash: store.project.hash });
 
           return HttpResponse.arrayBuffer(mockBufferRes, {
             status: 201,
@@ -375,11 +382,11 @@ describe("projectStore", () => {
         })
       );
 
-      await store.downloadZip(AnalysisType.MICROREACT, 1);
+      await store.downloadZip(AnalysisType.MICROREACT, "GPSC1");
 
       expect(URL.createObjectURL).toHaveBeenCalledWith(expect.objectContaining({ size: 10, type: "application/zip" }));
       expect(mockFileLink.href).toBe(fakeObjectUrl);
-      expect(mockFileLink.download).toBe(`${AnalysisType.MICROREACT}_cluster1.zip`);
+      expect(mockFileLink.download).toBe(`${AnalysisType.MICROREACT}_clusterGPSC1.zip`);
       expect(mockFileLink.click).toHaveBeenCalled();
       expect(URL.revokeObjectURL).toHaveBeenCalledWith(fakeObjectUrl);
     });
@@ -389,7 +396,7 @@ describe("projectStore", () => {
 
       server.use(http.post(`${getApiUrl()}/downloadZip`, () => HttpResponse.error()));
 
-      await store.downloadZip(AnalysisType.MICROREACT, 1);
+      await store.downloadZip(AnalysisType.MICROREACT, "GPSC1");
 
       expect(URL.createObjectURL).not.toHaveBeenCalled();
     });

--- a/app/client-v2/src/components/ProjectView/MicroReactColumn.vue
+++ b/app/client-v2/src/components/ProjectView/MicroReactColumn.vue
@@ -2,7 +2,6 @@
 import { useMicroreact } from "@/composables/useMicroreact";
 import { useProjectStore } from "@/stores/projectStore";
 import { type ProjectSample, AnalysisType } from "@/types/projectTypes";
-import Toast from "primevue/toast";
 import Dialog from "primevue/dialog";
 const props = defineProps<{
   data: ProjectSample;
@@ -20,7 +19,6 @@ const {
 </script>
 
 <template>
-  <Toast />
   <Dialog
     v-if="props.data.cluster"
     v-model:visible="isMicroReactDialogVisible"

--- a/app/client-v2/src/components/ProjectView/ProjectPage.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPage.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router";
 import ProjectPostRun from "@/components/ProjectView/ProjectPostRun.vue";
 import ProjectPreRun from "@/components/ProjectView/ProjectPreRun.vue";
 import { onUnmounted } from "vue";
+import Toast from "primevue/toast";
 
 const route = useRoute();
 const store = useProjectStore();
@@ -15,6 +16,7 @@ onUnmounted(() => {
 </script>
 
 <template>
+  <Toast />
   <div v-if="projectFetchError" class="text-red-500 text-center font-semibold flex align-items-center">
     Error fetching project... Refresh or try again later
   </div>

--- a/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
@@ -2,12 +2,14 @@
 import { useProjectStore } from "@/stores/projectStore";
 import ProjectDataTable from "@/components/ProjectView/ProjectDataTable.vue";
 import { ref } from "vue";
+import Toast from "primevue/toast";
 
 const store = useProjectStore();
 const tableIsHovered = ref(false);
 </script>
 
 <template>
+  <Toast />
   <FileUpload custom-upload auto @uploader="store.onFilesUpload($event.files)" :multiple="true" accept=".fa, .fasta">
     <template #header="{ chooseCallback }">
       <div class="flex flex-wrap justify-content-between align-items-center flex-1 gap-2">
@@ -15,7 +17,7 @@ const tableIsHovered = ref(false);
         <Button label="Run Analysis" outlined @click="store.runAnalysis" :disabled="!store.isReadyToRun" />
       </div>
     </template>
-    <template #content>
+    <template #empty>
       <div
         v-if="store.project.samples.length > 0"
         @dragover="tableIsHovered = true"

--- a/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
@@ -2,14 +2,12 @@
 import { useProjectStore } from "@/stores/projectStore";
 import ProjectDataTable from "@/components/ProjectView/ProjectDataTable.vue";
 import { ref } from "vue";
-import Toast from "primevue/toast";
 
 const store = useProjectStore();
 const tableIsHovered = ref(false);
 </script>
 
 <template>
-  <Toast />
   <FileUpload custom-upload auto @uploader="store.onFilesUpload($event.files)" :multiple="true" accept=".fa, .fasta">
     <template #header="{ chooseCallback }">
       <div class="flex flex-wrap justify-content-between align-items-center flex-1 gap-2">

--- a/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
@@ -30,7 +30,7 @@ const tableIsHovered = ref(false);
           <template #extra-cols>
             <Column>
               <!-- TODO: have to add endpoint to remove stored data as well -->
-              <!-- <template #body="props">
+              <template #body="props">
                 <Button
                   icon="pi pi-times"
                   @click="store.removeUploadedFile(props.index)"
@@ -39,7 +39,7 @@ const tableIsHovered = ref(false);
                   size="small"
                   severity="danger"
                 />
-              </template> -->
+              </template>
             </Column>
           </template>
         </ProjectDataTable>

--- a/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
@@ -27,7 +27,6 @@ const tableIsHovered = ref(false);
         <ProjectDataTable>
           <template #extra-cols>
             <Column>
-              <!-- TODO: have to add endpoint to remove stored data as well -->
               <template #body="props">
                 <Button
                   icon="pi pi-times"

--- a/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPreRun.vue
@@ -35,6 +35,7 @@ const tableIsHovered = ref(false);
                   rounded
                   size="small"
                   severity="danger"
+                  aria-label="`Remove ${props.rowData.name}`"
                 />
               </template>
             </Column>

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -62,6 +62,7 @@ export const useProjectStore = defineStore("project", {
         return error;
       }
     },
+
     showErrorToast(msg: string) {
       this.toast.add({
         severity: "error",

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -153,6 +153,7 @@ export const useProjectStore = defineStore("project", {
           stopPolling = true;
         }
       } catch (error) {
+        this.showErrorToast("Error fetching analysis status. Try again later, or create a new project.");
         console.error(error);
         stopPolling = true;
       } finally {
@@ -246,6 +247,7 @@ export const useProjectStore = defineStore("project", {
         URL.revokeObjectURL(link.href);
       } catch (error) {
         console.error(error);
+        this.showErrorToast("Error downloading zip file. Try again later.");
       }
     }
   }

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -18,7 +18,6 @@ import { Md5 } from "ts-md5";
 
 const baseApi = mande(getApiUrl(), { credentials: "include" });
 
-// TODO: add proper error handling. Maybe best to add error state attribute and watch accordingly cos of nested things interval/workers
 export const useProjectStore = defineStore("project", {
   state: () => ({
     project: {} as Project,
@@ -188,10 +187,15 @@ export const useProjectStore = defineStore("project", {
         this.pollingIntervalId = null;
       }
     },
-    // TODO: update to remove from api as well
-    // removeUploadedFile(index: number) {
-    //   // this.fileSamples.splice(index, 1);
-    // },
+    async removeUploadedFile(index: number) {
+      try {
+        await baseApi.post(`/project/${this.project.id}/sample/${this.project.samples[index].hash}/delete`);
+        this.project.samples.splice(index, 1);
+      } catch (error) {
+        console.error(error);
+        this.showErrorToast("Error removing file. Try again later.");
+      }
+    },
 
     async runAnalysis() {
       const body = this.buildRunAnalysisPostBody();

--- a/app/server/src/controllers/projectController.ts
+++ b/app/server/src/controllers/projectController.ts
@@ -42,7 +42,7 @@ export default (config) => {
           projectId
         );
 
-        // If there is no project hash, then the project has not been submitted so will have no poppunk result data available from beebop_py yet        
+        // If there is no project hash, then the project has not been submitted so will have no poppunk result data available from beebop_py yet
         if (!baseProjectInfo.hash) {
           const responseSamples = await ProjectUtils.getResponseSamples(
             store,
@@ -55,7 +55,7 @@ export default (config) => {
             samples: responseSamples,
           });
         }
-        
+
         let ranProjectResponse: AxiosResponse<APIResponse<APIProjectResponse>>;
         try {
           ranProjectResponse = await axios.get(
@@ -104,6 +104,14 @@ export default (config) => {
           filename,
           sketch
         );
+        sendSuccess(response, null);
+      });
+    },
+    async deleteSample(request, response, next) {
+      await asyncHandler(next, async () => {
+        const { projectId, sampleHash } = request.params;
+        const { redis } = request.app.locals;
+        await userStore(redis).deleteSample(projectId, sampleHash);
         sendSuccess(response, null);
       });
     },

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -100,7 +100,7 @@ export class UserStore {
     }
     async deleteSample(projectId: string, sampleHash: string) {
         const sampleIds = await this._redis.smembers(this._projectSamplesKey(projectId));
-        const sampleId = sampleIds.find((id) => id.startsWith(sampleHash));
+        const sampleId = sampleIds?.find((id) => id.startsWith(sampleHash));
         await this._redis.srem(this._projectSamplesKey(projectId), sampleId);
         await this._redis.del(this._projectSampleKey(projectId, sampleId));
     }

--- a/app/server/src/db/userStore.ts
+++ b/app/server/src/db/userStore.ts
@@ -98,6 +98,12 @@ export class UserStore {
         const amrString = await this._redis.hget(this._projectSampleKey(projectId, sampleId), "amr");
         return JSON.parse(amrString);
     }
+    async deleteSample(projectId: string, sampleHash: string) {
+        const sampleIds = await this._redis.smembers(this._projectSamplesKey(projectId));
+        const sampleId = sampleIds.find((id) => id.startsWith(sampleHash));
+        await this._redis.srem(this._projectSamplesKey(projectId), sampleId);
+        await this._redis.del(this._projectSampleKey(projectId, sampleId));
+    }
 
     async getSample(projectId: string, sampleHash: string, filename: string): Promise<{ sketch: Record<string, unknown>; amr: AMR }> {
         const sampleId = this._sampleId(sampleHash, filename);

--- a/app/server/src/routes/projectRoutes.ts
+++ b/app/server/src/routes/projectRoutes.ts
@@ -25,7 +25,7 @@ export default {
             authCheck,
             controller.renameProject);
         app.post(`/project/:projectId/sample/:sampleHash/delete`,
-        authCheck, 
-        controller.deleteSample);
+            authCheck, 
+            controller.deleteSample);
     }
 } as BeebopRoutes;

--- a/app/server/src/routes/projectRoutes.ts
+++ b/app/server/src/routes/projectRoutes.ts
@@ -24,5 +24,8 @@ export default {
         app.post('/project/:projectId/rename',
             authCheck,
             controller.renameProject);
+        app.post(`/project/:projectId/sample/:sampleHash/delete`,
+        authCheck, 
+        controller.deleteSample);
     }
 } as BeebopRoutes;

--- a/app/server/tests/unit/controllers/projectController.test.ts
+++ b/app/server/tests/unit/controllers/projectController.test.ts
@@ -25,7 +25,8 @@ const mockUserStore = {
     getSample: jest.fn().mockImplementation(() => ({
         sketch: "test sketch",
         amr: "test amr"
-    }))
+    })),
+    deleteSample: jest.fn(),
 };
 jest.mock("../../../src/db/userStore", () => ({
     userStore: mockUserStoreConstructor.mockReturnValue(mockUserStore)
@@ -290,4 +291,19 @@ describe("projectController", () => {
             errors: [{error: "PROJECT_ERROR", detail: "test project error"}]
         });
     });
+
+    it("deleteSample calls userStore deleteSample with correct params", async () => {
+        const req = {
+            app: mockApp,
+            params: {
+                projectId: "testProjectId",
+                sampleHash: "1234"
+            }
+        };
+
+        await projectController(config).deleteSample(req, mockResponse(),jest.fn());
+
+        expect(mockUserStore.deleteSample).toHaveBeenCalledTimes(1);
+        expect(mockUserStore.deleteSample).toHaveBeenCalledWith("testProjectId", "1234");
+    })
 });


### PR DESCRIPTION
This PR contains error handling with the projectStore and also functionality to delete sample files. Elobarted more in detail below:

1. Basic error handling in project page. This is mostly toast messages in the `projectStore.ts`
2. Abiloty to remove file samples from un run projects. Added an endpoint in API and also UI to accompany this. 
3. Unit testing

For testing its best to test the removal of file samples when project is not run. Refresh and ensure that it is persisted.