### PR TITLE
Prove that tests fail when mocks are restored between tests

### DIFF
--- a/app/client-v2/setupTests.ts
+++ b/app/client-v2/setupTests.ts
@@ -7,6 +7,8 @@ beforeAll(() => {
 
 afterEach(() => {
   server.resetHandlers();
+  vi.restoreAllMocks();
+  // https://vitest.dev/api/vi.html#vi-spyon
 });
 
 afterAll(() => {


### PR DESCRIPTION
See https://vitest.dev/guide/mocking.html and https://vitest.dev/api/vi.html#vi-spyon: we need to make sure that tests aren't affecting each others' state, i.e. all mocks should be reset between tests without breaking the tests.