### PR TITLE
Mrc-198 Bug fix microreact dialog bug

### DIFF
--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
@@ -1,4 +1,3 @@
-import { MOCK_PROJECT_SAMPLES_BEFORE_RUN } from "./../../../mocks/mockObjects";
 import ProjectPostRun from "@/components/ProjectView/ProjectPostRun.vue";
 import { MOCK_PROJECT_SAMPLES, MOCK_PROJECT_SAMPLES_BEFORE_RUN } from "@/mocks/mockObjects";
 import { useProjectStore } from "@/stores/projectStore";

--- a/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
+++ b/app/client-v2/src/__tests__/components/ProjectView/ProjectPostRun.spec.ts
@@ -1,5 +1,6 @@
+import { MOCK_PROJECT_SAMPLES_BEFORE_RUN } from "./../../../mocks/mockObjects";
 import ProjectPostRun from "@/components/ProjectView/ProjectPostRun.vue";
-import { MOCK_PROJECT_SAMPLES } from "@/mocks/mockObjects";
+import { MOCK_PROJECT_SAMPLES, MOCK_PROJECT_SAMPLES_BEFORE_RUN } from "@/mocks/mockObjects";
 import { useProjectStore } from "@/stores/projectStore";
 import { createTestingPinia, type TestingPinia } from "@pinia/testing";
 import userEvent from "@testing-library/user-event";
@@ -16,7 +17,9 @@ const renderComponent = (testPinia: TestingPinia, shouldStubTable = true) =>
     global: {
       plugins: [PrimeVue, testPinia],
       stubs: {
-        MicroReactTokenDialog: true,
+        MicroReactTokenDialog: {
+          template: `<div>MicroReactTokenDialog</div>`
+        },
         ProjectDataTable: shouldStubTable && {
           template: `<div>Data Table</div>`
         },
@@ -183,6 +186,30 @@ describe("RunProject", () => {
     renderComponent(testPinia, false);
 
     expect(screen.getByRole("button", { name: /microreact settings/i })).toBeDisabled();
+  });
+
+  it("should render disabled microreact setting button when no assigned clusters", async () => {
+    const { testPinia } = setupPinia({
+      samples: MOCK_PROJECT_SAMPLES_BEFORE_RUN,
+      status: {
+        assign: "finished",
+        microreact: "finished",
+        network: "finished"
+      }
+    });
+    renderComponent(testPinia, false);
+
+    expect(screen.getByRole("button", { name: /microreact settings/i })).toBeDisabled();
+  });
+
+  it("should render MicroReactTokenDialog token dialog when firstAssignedCluster is not undefined", async () => {
+    const { testPinia } = setupPinia({
+      samples: [...MOCK_PROJECT_SAMPLES_BEFORE_RUN, MOCK_PROJECT_SAMPLES[0]]
+    });
+
+    renderComponent(testPinia, true);
+
+    expect(screen.getByText(/MicroReactTokenDialog/i)).toBeVisible();
   });
 
   it("should display failed tags on cluster, network, microreact if status is finished but no cluster", () => {

--- a/app/client-v2/src/__tests__/stores/projectStore.spec.ts
+++ b/app/client-v2/src/__tests__/stores/projectStore.spec.ts
@@ -82,6 +82,20 @@ describe("projectStore", () => {
       store.project.status = undefined;
       expect(store.hasStartedAtLeastOneRun).toBe(false);
     });
+    it("firstAssignedCluster returns the first assigned cluster", () => {
+      const store = useProjectStore();
+      store.project.samples = [
+        { hash: "sample3" },
+        { hash: "sample2" },
+        { hash: "sample1", cluster: "GPSC1" }
+      ] as unknown as ProjectSample[];
+      expect(store.firstAssignedCluster).toBe("GPSC1");
+    });
+    it("should return undefined when there is no assigned cluster", () => {
+      const store = useProjectStore();
+      store.project.samples = MOCK_PROJECT_SAMPLES_BEFORE_RUN;
+      expect(store.firstAssignedCluster).toBeUndefined();
+    });
   });
 
   describe("actions", () => {

--- a/app/client-v2/src/components/ProjectView/ProjectPostRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPostRun.vue
@@ -29,14 +29,14 @@ const getMicroreactSettingsTooltip = () => {
 
 <template>
   <MicroReactTokenDialog
-    v-if="projectStore.project.samples?.length > 0 && projectStore.project.samples[0]?.cluster"
+    v-if="projectStore.firstAssignedCluster"
     :isMicroReactDialogVisible="isMicroReactDialogVisible"
     :hasMicroReactError="hasMicroReactError"
     :isFetchingMicroreactUrl="isFetchingMicroreactUrl"
     :header="`${userStore.microreactToken ? 'Update or Delete' : 'Save'} Microreact Token`"
     :text="`${userStore.microreactToken ? 'Update token to change to utilize another Microreact account, or delete token if you no longer want to use Microreact.' : 'Please save Microreact token so Microreact graphs can be visited.'}`"
     @closeDialog="closeDialog"
-    @saveMicroreactToken="saveMicroreactToken(projectStore.project.samples[0].cluster, $event)"
+    @saveMicroreactToken="saveMicroreactToken(projectStore.firstAssignedCluster, $event)"
   />
   <ProjectFileUpload @onRunAnalysis="hasVisitedNetworkTab && (hasVisitedNetworkTab = false)">
     <TabView @update:active-index="tabChange">
@@ -90,7 +90,7 @@ const getMicroreactSettingsTooltip = () => {
                       text
                       icon="pi pi-cog"
                       @click="isMicroReactDialogVisible = true"
-                      :disabled="projectStore.project.status?.microreact !== 'finished'"
+                      :disabled="projectStore.project.status?.microreact !== 'finished' || !projectStore.firstAssignedCluster"
                       aria-label="Microreact settings"
                       size="small"
                     />

--- a/app/client-v2/src/components/ProjectView/ProjectPostRun.vue
+++ b/app/client-v2/src/components/ProjectView/ProjectPostRun.vue
@@ -90,7 +90,9 @@ const getMicroreactSettingsTooltip = () => {
                       text
                       icon="pi pi-cog"
                       @click="isMicroReactDialogVisible = true"
-                      :disabled="projectStore.project.status?.microreact !== 'finished' || !projectStore.firstAssignedCluster"
+                      :disabled="
+                        projectStore.project.status?.microreact !== 'finished' || !projectStore.firstAssignedCluster
+                      "
                       aria-label="Microreact settings"
                       size="small"
                     />

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -49,6 +49,9 @@ export const useProjectStore = defineStore("project", {
           this.numOfStatus) *
           100
       );
+    },
+    firstAssignedCluster(state): string | undefined {
+      return state.project.samples.find((sample: ProjectSample) => !!sample.cluster)?.cluster
     }
   },
 

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -51,7 +51,7 @@ export const useProjectStore = defineStore("project", {
       );
     },
     firstAssignedCluster(state): string | undefined {
-      return state.project.samples.find((sample: ProjectSample) => !!sample.cluster)?.cluster
+      return state.project.samples.find((sample: ProjectSample) => !!sample.cluster)?.cluster;
     }
   },
 


### PR DESCRIPTION
This PR fixes bug where in a project if the first sample failed and other samples passed after run, then the settings cog on the microreact cog would not open. This was because the dialog was only rendered if the first sample had a cluster assigned. This has now been updated so if any sample has a cluster assigned then the cog opens up dialog.



This is the cog
![image](https://github.com/user-attachments/assets/eced10f8-7147-4ef5-98a0-547b8d8a0ddb)
