### PR TITLE
Bacpop-209 Beebop:AMR info to Microreact

### DIFF
--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   playwright-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       STORAGE_PATH: ${{ github.workspace }}/storage/dbs
     strategy:
@@ -75,7 +75,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [playwright-tests]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwrightCI.yml
+++ b/.github/workflows/playwrightCI.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   playwright-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       STORAGE_PATH: ${{ github.workspace }}/storage/dbs
     strategy:
@@ -75,7 +75,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [playwright-tests]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/app/client-v2/src/__tests__/App.spec.ts
+++ b/app/client-v2/src/__tests__/App.spec.ts
@@ -4,7 +4,6 @@ import { createTestingPinia } from "@pinia/testing";
 import { render, screen } from "@testing-library/vue";
 import { defineComponent } from "vue";
 import { createRouter, createWebHistory } from "vue-router";
-import PrimeVue from "primevue/config";
 
 const mockedThemeValues = {
   setInitialTheme: vitest.fn(),

--- a/app/client-v2/src/__tests__/stores/projectStore.spec.ts
+++ b/app/client-v2/src/__tests__/stores/projectStore.spec.ts
@@ -698,7 +698,33 @@ describe("projectStore", () => {
           [MOCK_PROJECT_SAMPLES[0].hash]: MOCK_PROJECT_SAMPLES[0].sketch,
           [MOCK_PROJECT_SAMPLES[1].hash]: MOCK_PROJECT_SAMPLES[1].sketch,
           [MOCK_PROJECT_SAMPLES[2].hash]: MOCK_PROJECT_SAMPLES[2].sketch
-        }
+        },
+        amrForMetadataCsv: [
+          {
+            "Chloramphenicol Resistance": "Probably",
+            "Cotrim Resistance": "Probably not",
+            "Erythromycin Resistance": "Probably not",
+            ID: "sample1-test-hash",
+            "Penicillin Resistance": "Unlikely",
+            "Tetracycline Resistance": "Highly unlikely"
+          },
+          {
+            "Chloramphenicol Resistance": "Probably",
+            "Cotrim Resistance": "Almost certainly",
+            "Erythromycin Resistance": "Almost certainly",
+            ID: "sample2-test-hash",
+            "Penicillin Resistance": "Highly unlikely",
+            "Tetracycline Resistance": "Highly unlikely"
+          },
+          {
+            "Chloramphenicol Resistance": "Probably",
+            "Cotrim Resistance": "Unlikely",
+            "Erythromycin Resistance": "Probably not",
+            ID: "sample3-test-hash",
+            "Penicillin Resistance": "Probably",
+            "Tetracycline Resistance": "Highly unlikely"
+          }
+        ]
       });
     });
     it("should get download url & download when downloadZip is called", async () => {

--- a/app/client-v2/src/__tests__/utils/projectCsvUtils.spec.ts
+++ b/app/client-v2/src/__tests__/utils/projectCsvUtils.spec.ts
@@ -53,11 +53,11 @@ describe("projectCsvUtils", () => {
       const result = convertAmrForCsv(amr);
 
       expect(result).toEqual({
-        Penicillin: "word",
-        Chloramphenicol: "word",
-        Erythromycin: "word",
-        Tetracycline: "word",
-        Cotrim: "word"
+        "Penicillin Resistance": "word",
+        "Chloramphenicol Resistance": "word",
+        "Erythromycin Resistance": "word",
+        "Tetracycline Resistance": "word",
+        "Cotrim Resistance": "word"
       });
     });
   });

--- a/app/client-v2/src/stores/projectStore.ts
+++ b/app/client-v2/src/stores/projectStore.ts
@@ -186,7 +186,6 @@ export const useProjectStore = defineStore("project", {
       });
     },
     async handleWorkerResponse(samples: WorkerResponse[]) {
-      console.log("samples", samples);
       this.project.samples.push(...samples);
       try {
         await baseApi.post(`/project/${this.project.id}/sample`, samples);

--- a/app/client-v2/src/types/projectTypes.ts
+++ b/app/client-v2/src/types/projectTypes.ts
@@ -23,6 +23,17 @@ export interface AMR {
   species: boolean;
 }
 
+export interface AMRForCsv {
+  "Penicillin Resistance": string;
+  "Chloramphenicol Resistance": string;
+  "Erythromycin Resistance": string;
+  "Tetracycline Resistance": string;
+  "Cotrim Resistance": string;
+}
+
+export interface AMRMetadataCsv extends AMRForCsv {
+  ID: string;
+}
 export interface ProjectSample {
   hash: string;
   filename: string;

--- a/app/client-v2/src/utils/projectCsvUtils.ts
+++ b/app/client-v2/src/utils/projectCsvUtils.ts
@@ -1,4 +1,4 @@
-import type { AMR, ProjectSample } from "@/types/projectTypes";
+import type { AMR, AMRForCsv, ProjectSample } from "@/types/projectTypes";
 import { convertProbabilityToWord } from "./amrDisplayUtils";
 
 export const downloadCsv = (samples: ProjectSample[], filename: string) => {
@@ -12,12 +12,12 @@ export const downloadCsv = (samples: ProjectSample[], filename: string) => {
   triggerCsvDownload(csvContent, `${filename}.csv`);
 };
 
-export const convertAmrForCsv = (amr: AMR) => ({
-  Penicillin: convertProbabilityToWord(amr.Penicillin, "Penicillin"),
-  Chloramphenicol: convertProbabilityToWord(amr.Chloramphenicol, "Chloramphenicol"),
-  Erythromycin: convertProbabilityToWord(amr.Erythromycin, "Erythromycin"),
-  Tetracycline: convertProbabilityToWord(amr.Tetracycline, "Tetracycline"),
-  Cotrim: convertProbabilityToWord(amr.Trim_sulfa, "Cotrim")
+export const convertAmrForCsv = (amr: AMR): AMRForCsv => ({
+  "Penicillin Resistance": convertProbabilityToWord(amr.Penicillin, "Penicillin"),
+  "Chloramphenicol Resistance": convertProbabilityToWord(amr.Chloramphenicol, "Chloramphenicol"),
+  "Erythromycin Resistance": convertProbabilityToWord(amr.Erythromycin, "Erythromycin"),
+  "Tetracycline Resistance": convertProbabilityToWord(amr.Tetracycline, "Tetracycline"),
+  "Cotrim Resistance": convertProbabilityToWord(amr.Trim_sulfa, "Cotrim")
 });
 
 export const generateCsvContent = (data: Record<string, string>[]) => {

--- a/app/server/src/controllers/indexController.ts
+++ b/app/server/src/controllers/indexController.ts
@@ -14,10 +14,10 @@ export default (config) => {
         async runPoppunk(request, response, next) {
             await asyncHandler(next, async () => {
                 const poppunkRequest = request.body as BeebopRunRequest;
-                const {projectHash, projectId, names, sketches, species } = poppunkRequest;
+                const { projectHash, projectId, names, sketches, species, amrForMetadataCsv } = poppunkRequest;
                 const {redis} = request.app.locals;
                 await userStore(redis).saveHashAndSamplesRun(request, projectId, projectHash, names);
-                const apiRequest = { names, projectHash, sketches, species } as PoppunkRequest;
+                const apiRequest = { names, projectHash, sketches, species, amrForMetadataCsv } as PoppunkRequest;
                 await axios
                   .post(`${config.api_url}/poppunk`, apiRequest, {
                     headers: {

--- a/app/server/src/types/requestTypes.ts
+++ b/app/server/src/types/requestTypes.ts
@@ -5,8 +5,20 @@ export interface PoppunkRequest {
     projectHash: string,
     sketches: Record<string, never>
     species: string,
+    amrForMetadataCsv: AMRMetadataCsv[]
 }
 
+export interface AMRForCsv {
+    "Penicillin Resistance": string;
+    "Chloramphenicol Resistance": string;
+    "Erythromycin Resistance": string;
+    "Tetracycline Resistance": string;
+    "Cotrim Resistance": string;
+}
+
+export interface AMRMetadataCsv extends AMRForCsv {
+    ID: string;
+}
 export interface BeebopRunRequest extends PoppunkRequest {
     projectId: string,
 }

--- a/app/server/tests/integration/testSample.ts
+++ b/app/server/tests/integration/testSample.ts
@@ -13135,4 +13135,14 @@ export const testSample = (
     },
   },
   names: { fd38a3bc7197390fd3734240a67fb515: "7622_5#78.fa" },
+  amrForMetadataCsv: [
+    {
+      ID: "fd38a3bc7197390fd3734240a67fb515",
+      "Penicillin Resistance": "Highly unlikely",
+      "Chloramphenicol Resistance": "Unsure",
+      "Erythromycin Resistance": "Highly unlikely",
+      "Tetracycline Resistance": "Almost certainly",
+      "Cotrim Resistance": "Highly likely",
+    },
+  ],
 });

--- a/scripts/common
+++ b/scripts/common
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export API_IMAGE="bacpop-205-fix-network-dev"
+export API_IMAGE="bacpop-209-amr-microreact-dev" # TODO revert back to main before merge into main
 
 NETWORK=beebop_nw
 VOLUME=beebop-storage


### PR DESCRIPTION
This PR is in conjunction with [beebop_py pr](https://github.com/bacpop/beebop_py/pull/57).
The purpose is to pass along AMR information to an info_csv metadata file that is passed into visualise for microreact. This means that this AMR info will show on the table when visiting microreact page.

Also added Status column as default into microreact and sorted so query samples show first before ref samples. 

Testing:
Create a project with samples and run. Then visit microreact, the AMR columns should show by default and query samples should be on top of ref samples. 
have also deployed on [beebop-dev](https://beebop-dev.dide.ic.ac.uk/) if its easier 