### PR TITLE
Network library change updates

### DIFF
--- a/app/client-v2/src/components/ProjectView/CytoscapeCanvas.vue
+++ b/app/client-v2/src/components/ProjectView/CytoscapeCanvas.vue
@@ -29,14 +29,14 @@ onMounted(async () => {
         style: {
           width: "10px",
           height: "10px",
-          content: "data(d1)",
+          content: "data(key2)",
           "font-size": "7px",
           color: "#00CC66",
           "background-color": "rgba(45, 212, 191, 0.44)"
         }
       },
       {
-        selector: 'node[d2 = "query"]',
+        selector: 'node[key3 = "query"]',
         style: {
           "background-color": "crimson",
           color: "crimson"

--- a/scripts/common
+++ b/scripts/common
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export API_IMAGE="bacpop-208-nw-mc-1-call" # TODO revert before merge
+export API_IMAGE="main"
 
 NETWORK=beebop_nw
 VOLUME=beebop-storage


### PR DESCRIPTION
This is the corresponding changes to [beebop_py pr](http://localhost:5173/project/ec3fa538308bf6c7fc0e617b28d01bce). This is needed as new graph library graph-tool produces slightly different key names.


Testing: 
test with the beebop_py branch by setting API_BRANCH=speedup-subgraph-creation in common.
The network graph should still be working and not broken