### PR TITLE
Fix: Sublineage not showing on csv download

### DIFF
--- a/app/client-v2/src/__tests__/utils/projectCsvUtils.spec.ts
+++ b/app/client-v2/src/__tests__/utils/projectCsvUtils.spec.ts
@@ -87,6 +87,32 @@ describe("projectCsvUtils", () => {
 
       expect(result).toBe("");
     });
+
+    it("should handle data with missing fields gracefully", () => {
+      const data = [
+        { filename: "sample1", Penicillin: "Penicillin-0.9", cluster: "cluster1" },
+        { filename: "sample2", cluster: "cluster2" } // Missing Penicillin field
+      ];
+
+      const result = generateCsvContent(data as Record<string, string>[]);
+
+      expect(result).toBe(
+        'filename,Penicillin,cluster\n"sample1","Penicillin-0.9","cluster1"\n"sample2","","cluster2"'
+      );
+    });
+
+    it("should handle data with varying fields and maintain consistent headers", () => {
+      const data = [
+        { filename: "sample1", Penicillin: "Penicillin-0.9", cluster: "cluster1" },
+        { filename: "sample2", Chloramphenicol: "Chloramphenicol-0.8" } // Different field
+      ];
+
+      const result = generateCsvContent(data as any);
+
+      expect(result).toBe(
+        'filename,Penicillin,cluster,Chloramphenicol\n"sample1","Penicillin-0.9","cluster1",""\n"sample2","","","Chloramphenicol-0.8"'
+      );
+    });
   });
 
   describe("triggerCsvDownload", () => {

--- a/app/client-v2/src/utils/projectCsvUtils.ts
+++ b/app/client-v2/src/utils/projectCsvUtils.ts
@@ -31,8 +31,8 @@ export const convertAmrForCsv = (amr: AMR): AMRForCsv => ({
 export const generateCsvContent = (data: Record<string, string>[]) => {
   if (data.length === 0) return "";
 
-  const headers = Object.keys(data[0]);
-  const rows = data.map((row) => headers.map((header) => `"${row[header]}"`).join(","));
+  const headers = Array.from(new Set(data.flatMap((row) => Object.keys(row))));
+  const rows = data.map((row) => headers.map((header) => `"${row[header] ?? ""}"`).join(","));
   return [headers.join(","), ...rows].join("\n");
 };
 


### PR DESCRIPTION
There was issue that sublinages was not showing on csv download. this was because we use the first sample for all headers. so if there is missing sublineage for that field then then the csv would be missng header thus field... Thus now checking all samples for headers. 

Also have it to show empty string if field not exists. this is much cleaner than old 'undefined' that used to show

Testing:
add samples and run. then run export as see sublinages and if any missing then will show empty string... Try `S_pneumoniae_Hungary19A_6_GCF_000019265_1.fa and S_pneumoniae_M26368_GCF_003351725_1.fa` (no sublinage) + `S_pneumoniae_D39V_GCF_003003495_1.fa` ... message me if you dont have these samples